### PR TITLE
[WIP] output version number parts as properties

### DIFF
--- a/MinVer.Lib/Version.cs
+++ b/MinVer.Lib/Version.cs
@@ -9,9 +9,6 @@ namespace MinVer.Lib
     public class Version : IComparable<Version>
 #pragma warning restore CA1036 // Override methods on comparable types
     {
-        private readonly int major;
-        private readonly int minor;
-        private readonly int patch;
         private readonly List<string> preReleaseIdentifiers;
         private readonly int height;
         private readonly string buildMetadata;
@@ -22,32 +19,44 @@ namespace MinVer.Lib
 
         private Version(int major, int minor, int patch, IEnumerable<string> preReleaseIdentifiers, int height, string buildMetadata)
         {
-            this.major = major;
-            this.minor = minor;
-            this.patch = patch;
+            this.Major = major;
+            this.Minor = minor;
+            this.Patch = patch;
             this.preReleaseIdentifiers = preReleaseIdentifiers?.ToList() ?? new List<string>();
             this.height = height;
             this.buildMetadata = buildMetadata;
         }
 
+        public int Major { get; }
+
+        public int Minor { get; }
+
+        public int Patch { get; }
+
+        public string ToPrefix() =>
+            $"{this.Major}.{this.Minor}.{this.Patch}";
+
+        public string ToSuffix() =>
+            $"{string.Join(".", this.preReleaseIdentifiers)}{(this.height == 0 ? "" : $".{this.height}")}";
+
         public override string ToString() =>
-            $"{this.major}.{this.minor}.{this.patch}{(this.preReleaseIdentifiers.Count == 0 ? "" : $"-{string.Join(".", this.preReleaseIdentifiers)}")}{(this.height == 0 ? "" : $".{this.height}")}{(string.IsNullOrEmpty(this.buildMetadata) ? "" : $"+{this.buildMetadata}")}";
+            $"{this.ToPrefix()}{(this.preReleaseIdentifiers.Count == 0 ? "" : $"-{this.ToSuffix()}")}{(string.IsNullOrEmpty(this.buildMetadata) ? "" : $"+{this.buildMetadata}")}";
 
         public int CompareTo(Version other)
         {
-            var major = this.major.CompareTo(other.major);
+            var major = this.Major.CompareTo(other.Major);
             if (major != 0)
             {
                 return major;
             }
 
-            var minor = this.minor.CompareTo(other.minor);
+            var minor = this.Minor.CompareTo(other.Minor);
             if (minor != 0)
             {
                 return minor;
             }
 
-            var patch = this.patch.CompareTo(other.patch);
+            var patch = this.Patch.CompareTo(other.Patch);
             if (patch != 0)
             {
                 return patch;
@@ -99,16 +108,16 @@ namespace MinVer.Lib
 
         public Version WithHeight(int height) =>
             this.preReleaseIdentifiers.Count == 0 && height > 0
-                ? new Version(this.major, this.minor, this.patch + 1, new[] { "alpha", "0" }, height, default)
-                : new Version(this.major, this.minor, this.patch, this.preReleaseIdentifiers, height, height == 0 ? this.buildMetadata : default);
+                ? new Version(this.Major, this.Minor, this.Patch + 1, new[] { "alpha", "0" }, height, default)
+                : new Version(this.Major, this.Minor, this.Patch, this.preReleaseIdentifiers, height, height == 0 ? this.buildMetadata : default);
 
         public Version AddBuildMetadata(string buildMetadata)
         {
             var separator = !string.IsNullOrEmpty(this.buildMetadata) && !string.IsNullOrEmpty(buildMetadata) ? "." : "";
-            return new Version(this.major, this.minor, this.patch, this.preReleaseIdentifiers, this.height, $"{this.buildMetadata}{separator}{buildMetadata}");
+            return new Version(this.Major, this.Minor, this.Patch, this.preReleaseIdentifiers, this.height, $"{this.buildMetadata}{separator}{buildMetadata}");
         }
 
-        public bool IsBefore(int major, int minor) => this.major < major || (this.major == major && this.minor < minor);
+        public bool IsBefore(int major, int minor) => this.Major < major || (this.Major == major && this.Minor < minor);
 
         public static Version ParseOrDefault(string text, string prefix) =>
             text == default || !text.StartsWith(prefix ?? "") ? default : ParseOrDefault(text.Substring(prefix?.Length ?? 0));

--- a/MinVer/TextWriterExtensions.cs
+++ b/MinVer/TextWriterExtensions.cs
@@ -1,0 +1,18 @@
+namespace MinVer
+{
+    using System.IO;
+    using MinVer.Lib;
+
+    internal static class TextWriterExtensions
+    {
+        public static void WriteVersion(this TextWriter writer, Version version)
+        {
+            writer.WriteLine($"Version:{version}");
+            writer.WriteLine($"VersionPrefix:{version.ToPrefix()}");
+            writer.WriteLine($"VersionSuffix:{version.ToSuffix()}");
+            writer.WriteLine($"Major:{version.Major}");
+            writer.WriteLine($"Minor:{version.Minor}");
+            writer.WriteLine($"Patch:{version.Patch}");
+        }
+    }
+}

--- a/MinVer/build/MinVer.targets
+++ b/MinVer/build/MinVer.targets
@@ -17,10 +17,26 @@
       <Output TaskParameter="ConsoleOutput" ItemName="MinVerConsoleOutput" />
     </Exec>
     <ItemGroup>
-      <MinVerOutput Include="@(MinVerConsoleOutput)" Condition="'$([System.String]::new(`%(Identity)`).StartsWith(`MinVer:`))' != 'true'" />
+      <MinVerOutputVersion Include="@(MinVerConsoleOutput)" Condition="'$([System.String]::new(`%(Identity)`).StartsWith(`Version:`))' == 'true'" />
+      <MinVerOutputVersionPrefix Include="@(MinVerConsoleOutput)" Condition="'$([System.String]::new(`%(Identity)`).StartsWith(`VersionPrefix:`))' == 'true'" />
+      <MinVerOutputVersionSuffix Include="@(MinVerConsoleOutput)" Condition="'$([System.String]::new(`%(Identity)`).StartsWith(`VersionSuffix:`))' == 'true'" />
+      <MinVerOutputMajor Include="@(MinVerConsoleOutput)" Condition="'$([System.String]::new(`%(Identity)`).StartsWith(`Major:`))' == 'true'" />
+      <MinVerOutputMinor Include="@(MinVerConsoleOutput)" Condition="'$([System.String]::new(`%(Identity)`).StartsWith(`Minor:`))' == 'true'" />
+      <MinVerOutputPatch Include="@(MinVerConsoleOutput)" Condition="'$([System.String]::new(`%(Identity)`).StartsWith(`Patch:`))' == 'true'" />
     </ItemGroup>
     <PropertyGroup>
-      <MinVerVersion>@(MinVerOutput)</MinVerVersion>
+      <MinVerVersion>@(MinVerOutputVersion)</MinVerVersion>
+      <MinVerVersionPrefix>@(MinVerOutputVersionPrefix)</MinVerVersionPrefix>
+      <MinVerVersionSuffix>@(MinVerOutputVersionSuffix)</MinVerVersionSuffix>
+      <MinVerMajor>@(MinVerOutputMajor)</MinVerMajor>
+      <MinVerMinor>@(MinVerOutputMinor)</MinVerMinor>
+      <MinVerPatch>@(MinVerOutputPatch)</MinVerPatch>
+      <MinVerVersion>$([System.String]::new(`$(MinVerVersion)`).Substring(8))</MinVerVersion>
+      <MinVerVersionPrefix>$([System.String]::new(`$(MinVerVersionPrefix)`).Substring(14))</MinVerVersionPrefix>
+      <MinVerVersionSuffix>$([System.String]::new(`$(MinVerVersionSuffix)`).Substring(14))</MinVerVersionSuffix>
+      <MinVerMajor>$([System.String]::new(`$(MinVerMajor)`).Substring(6))</MinVerMajor>
+      <MinVerMinor>$([System.String]::new(`$(MinVerMinor)`).Substring(6))</MinVerMinor>
+      <MinVerPatch>$([System.String]::new(`$(MinVerPatch)`).Substring(6))</MinVerPatch>
     </PropertyGroup>
   </Target>
 
@@ -34,6 +50,8 @@
   <Target Name="MinVer" BeforeTargets="CoreCompile;GenerateNuspec" DependsOnTargets="MinVer_GetVersion" Condition="'$(UsingMicrosoftNETSdk)' == 'true' And '$(DesignTimeBuild)' != 'true'">
     <PropertyGroup>
       <Version>$(MinVerVersion)</Version>
+      <VersionPrefix>$(MinVerVersionPrefix)</VersionPrefix>
+      <VersionSuffix>$(MinVerVersionSuffix)</VersionSuffix>
       <PackageVersion>$(MinVerVersion)</PackageVersion>
     </PropertyGroup>
   </Target>

--- a/minver-cli/Program.cs
+++ b/minver-cli/Program.cs
@@ -32,7 +32,7 @@ namespace MinVer
 
                 var version = GetVersion(path, tagPrefix.Value(), range, buildMetadata.Value(), level);
 
-                Console.Out.WriteLine(version);
+                Console.Out.WriteVersion(version);
 
                 return 0;
             });

--- a/minver-cli/TextWriterExtensions.cs
+++ b/minver-cli/TextWriterExtensions.cs
@@ -1,0 +1,10 @@
+namespace MinVer
+{
+    using System.IO;
+    using MinVer.Lib;
+
+    internal static class TextWriterExtensions
+    {
+        public static void WriteVersion(this TextWriter writer, Version version) => writer.WriteLine(version);
+    }
+}


### PR DESCRIPTION
@bording this is a horrid attempt at solving #109.

Functionally, it's fine, although the downside is a whole lot more noise in the build output. The stdout side-effect of using the `Exec` task goes from one line to six (although this will go away with #112):

```
Version:2.0.0-alpha.0.1+build.42
VersionPrefix:2.0.0
VersionSuffix:alpha.0.1
Major:2
Minor:0
Patch:0
```

Code-wise, it's awful. Specially since taking a substring directly on `@(MinVerOutputVersion)`, etc. didn't work (or at least my MSBuild-fu failed me) so I had to do that in a second series of property assignments.

Can you think of a better way? 🤞

One more thing is that this may also require a re-consideration of the `MinVerVersionOverride` scenario, since currently, the only properties which would be set are `Version` and `PackageVersion`. Either the README would need to be updated to reflect the added burden on the user to set `VersionPrefix` and `VersionSuffix, `MinVerMajor`, `MinVerMinor`, and `MinVerPatch` manually, which is horrible, or the version override should be fed into `MinVer.dll` so that it can be pulled apart into those various properties. This is marked as WIP on that basis.

Closes #109.