### PR TITLE
ensure build metadata and major minor are used when there are no commits

### DIFF
--- a/MinVer.Lib/Version.cs
+++ b/MinVer.Lib/Version.cs
@@ -17,6 +17,8 @@ namespace MinVer.Lib
 
         public Version(int major, int minor) : this(major, minor, default, new List<string> { "alpha", "0" }, default, default) { }
 
+        public Version(int major, int minor, string buildMetadata) : this(major, minor, default, new List<string> { "alpha", "0" }, default, buildMetadata) { }
+
         private Version(int major, int minor, int patch, IEnumerable<string> preReleaseIdentifiers, int height, string buildMetadata)
         {
             this.Major = major;

--- a/MinVer.Lib/Versioner.cs
+++ b/MinVer.Lib/Versioner.cs
@@ -19,7 +19,7 @@ namespace MinVer.Lib
             if (commit == default)
             {
                 log.Info("No commits found. Using default version.");
-                return new Version();
+                return new Version(range?.Major ?? 0, range?.Minor ?? 0, buildMetadata);
             }
 
             var tagsAndVersions = repo.Tags

--- a/MinVerTests/BuildMetadata.cs
+++ b/MinVerTests/BuildMetadata.cs
@@ -14,6 +14,21 @@ namespace MinVerTests
     public static class BuildMetadata
     {
         [Scenario]
+        [Example(default, "0.0.0-alpha.0")]
+        [Example("a", "0.0.0-alpha.0+a")]
+        public static void NoTag(string buildMetadata, string expectedVersion, string path, Repository repo, Version actualVersion)
+        {
+            $"Given a git repository with a commit in '{path = GetScenarioDirectory($"build-metadata-no-tag-{buildMetadata}")}'"
+                .x(c => repo = EnsureEmptyRepositoryAndCommit(path).Using(c));
+
+            $"When the version is determined using build metadata '{buildMetadata}'"
+                .x(() => actualVersion = Versioner.GetVersion(repo, default, default, buildMetadata, new TestLogger()));
+
+            $"Then the version is '{expectedVersion}'"
+                .x(() => Assert.Equal(expectedVersion, actualVersion.ToString()));
+        }
+
+        [Scenario]
         [Example("1.2.3+a", default, "1.2.3+a")]
         [Example("1.2.3", "b", "1.2.3+b")]
         [Example("1.2.3+a", "b", "1.2.3+a.b")]

--- a/MinVerTests/BuildMetadata.cs
+++ b/MinVerTests/BuildMetadata.cs
@@ -16,6 +16,21 @@ namespace MinVerTests
         [Scenario]
         [Example(default, "0.0.0-alpha.0")]
         [Example("a", "0.0.0-alpha.0+a")]
+        public static void NoCommits(string buildMetadata, string expectedVersion, string path, Repository repo, Version actualVersion)
+        {
+            $"Given an empty git repository in '{path = GetScenarioDirectory($"build-metadata-no-tag-{buildMetadata}")}'"
+                .x(c => repo = EnsureEmptyRepository(path).Using(c));
+
+            $"When the version is determined using build metadata '{buildMetadata}'"
+                .x(() => actualVersion = Versioner.GetVersion(repo, default, default, buildMetadata, new TestLogger()));
+
+            $"Then the version is '{expectedVersion}'"
+                .x(() => Assert.Equal(expectedVersion, actualVersion.ToString()));
+        }
+
+        [Scenario]
+        [Example(default, "0.0.0-alpha.0")]
+        [Example("a", "0.0.0-alpha.0+a")]
         public static void NoTag(string buildMetadata, string expectedVersion, string path, Repository repo, Version actualVersion)
         {
             $"Given a git repository with a commit in '{path = GetScenarioDirectory($"build-metadata-no-tag-{buildMetadata}")}'"

--- a/MinVerTests/MajorMinor.cs
+++ b/MinVerTests/MajorMinor.cs
@@ -14,6 +14,19 @@ namespace MinVerTests
     public static class MajorMinor
     {
         [Scenario]
+        public static void NoCommits(string path, Repository repo, Version actualVersion)
+        {
+            $"Given an empty git repository in '{path = GetScenarioDirectory($"major-minor-not-tagged")}'"
+                .x(c => repo = EnsureEmptyRepository(path).Using(c));
+
+            "When the version is determined using major minor '1.2'"
+                .x(() => actualVersion = Versioner.GetVersion(new Repository(path), default, new MinVer.Lib.MajorMinor(1, 2), default, new TestLogger()));
+
+            $"Then the version is '1.2.0-alpha.0'"
+                .x(() => Assert.Equal("1.2.0-alpha.0", actualVersion.ToString()));
+        }
+
+        [Scenario]
         [Example("2.0.0", 1, 0, "2.0.0")]
         [Example("2.0.0", 2, 0, "2.0.0")]
         [Example("2.0.0", 3, 0, "3.0.0-alpha.0")]

--- a/minver-cli/Program.cs
+++ b/minver-cli/Program.cs
@@ -73,7 +73,7 @@ namespace MinVer
 
             if (!RepositoryEx.TryCreateRepo(path, out var repo))
             {
-                var version = new Version();
+                var version = new Version(range?.Major ?? 0, range?.Minor ?? 0, buildMetadata);
 
                 log.WarnInvalidRepoPath(path, version);
 


### PR DESCRIPTION
Relates to #2
Relates to #28
Relates to #63