### PR TITLE
Revert "switch to license expression"

### DIFF
--- a/MinVer/MinVer.csproj
+++ b/MinVer/MinVer.csproj
@@ -7,7 +7,7 @@
     <NoWarn>$(NoWarn);NU5100;NU5105</NoWarn>
     <OutputType>Exe</OutputType>
     <PackageIconUrl>https://raw.githubusercontent.com/adamralph/minver/master/assets/minver.png</PackageIconUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageLicenseUrl>https://github.com/adamralph/minver/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/adamralph/minver</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/adamralph/minver/milestones?state=closed</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/minver-cli/minver-cli.csproj
+++ b/minver-cli/minver-cli.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <PackageIconUrl>https://raw.githubusercontent.com/adamralph/minver/master/assets/minver.png</PackageIconUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <PackageLicenseUrl>https://github.com/adamralph/minver/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/adamralph/minver</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/adamralph/minver/milestones?state=closed</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
This reverts commit b61f7bb74723ae8d52aeb1d0b3d18b643859af7a.

Cannot use `PackageLicenseExpression` until Appveyor gets .NET SDK 2.1.500.