### PR TITLE
Revert "refactor discovery"

### DIFF
--- a/MinVer.Lib/RepositoryEx.cs
+++ b/MinVer.Lib/RepositoryEx.cs
@@ -1,5 +1,6 @@
 namespace MinVer.Lib
 {
+    using System.IO;
     using LibGit2Sharp;
 
     public static class RepositoryEx
@@ -8,16 +9,20 @@ namespace MinVer.Lib
         {
             repository = default;
 
-            path = Repository.Discover(path);
-
-            if (path == default)
+            while (path != default)
             {
-                return false;
+                try
+                {
+                    repository = new Repository(path);
+                    return true;
+                }
+                catch (RepositoryNotFoundException)
+                {
+                    path = Directory.GetParent(path)?.FullName;
+                }
             }
 
-            repository = new Repository(path);
-
-            return true;
+            return false;
         }
     }
 }


### PR DESCRIPTION
This reverts commit 4d5da7f0d466a86a42f7673357a3d4ba9b346890.

As demonstrated in https://github.com/SQLStreamStore/SQLStreamStore.HAL/pull/38#issuecomment-441652214 there's a bug in `Repository.Discover()` which only seems to manifest in the context of Docker.