### PR TITLE
remove redundant IsTestProject property

### DIFF
--- a/MinVer.Lib/MinVer.Lib.csproj
+++ b/MinVer.Lib/MinVer.Lib.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsTestProject>false</IsTestProject>
     <NoWarn>$(NoWarn);CA1716</NoWarn>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>

--- a/MinVer/MinVer.csproj
+++ b/MinVer/MinVer.csproj
@@ -4,7 +4,6 @@
     <Description>Minimalistic versioning for .NET SDK-style projects using Git tags.</Description>
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <IsTestProject>false</IsTestProject>
     <NoWarn>$(NoWarn);NU5100;NU5105</NoWarn>
     <OutputType>Exe</OutputType>
     <PackageIconUrl>https://raw.githubusercontent.com/adamralph/minver/master/assets/minver.png</PackageIconUrl>

--- a/MinVerTests/MinVerTests.csproj
+++ b/MinVerTests/MinVerTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsTestProject>true</IsTestProject>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 

--- a/minver-cli/minver-cli.csproj
+++ b/minver-cli/minver-cli.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <Description>A minimalistic command line tool for versioning any Git repository using tags.</Description>
-    <IsTestProject>false</IsTestProject>
     <NoWarn>$(NoWarn);NU5105</NoWarn>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>

--- a/targets/Targets.csproj
+++ b/targets/Targets.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsTestProject>false</IsTestProject>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>


### PR DESCRIPTION
This was added to remove this annoying message in anticipation of https://github.com/Microsoft/vstest/issues/1866:

> Skipping running test for project {project file}. To run tests with dotnet test add "true" property to project file.

But this is not the right solution. The log level for that message should be reduced, as per https://github.com/Microsoft/vstest/pull/1867/files#r244541222

For test projects, there is no need to set this property to `true`, since that is done by `Microsoft.NET.Test.Sdk`.