### PR TITLE
added implementation for selective version segment incrementation

### DIFF
--- a/MinVer.Lib/RepositoryExtensions.cs
+++ b/MinVer.Lib/RepositoryExtensions.cs
@@ -6,7 +6,7 @@ namespace MinVer.Lib
 
     internal static class RepositoryExtensions
     {
-        public static Version GetVersion(this Repository repo, string tagPrefix, ILogger log)
+        public static Version GetVersion(this Repository repo, string tagPrefix, VersionPart autoIncrement, ILogger log)
         {
             var commit = repo.Commits.FirstOrDefault();
 
@@ -175,7 +175,7 @@ namespace MinVer.Lib
 
             log.Info($"Using{(log.IsDebugEnabled && orderedCandidates.Count > 1 ? "    " : " ")}{selectedCandidate.ToString(tagWidth, versionWidth, heightWidth)}.");
 
-            return selectedCandidate.Version.WithHeight(selectedCandidate.Height);
+            return selectedCandidate.Version.WithHeight(selectedCandidate.Height, autoIncrement);
         }
 
         public static string ShortSha(this Commit commit) => commit.Sha.Substring(0, 7);

--- a/MinVer.Lib/Version.cs
+++ b/MinVer.Lib/Version.cs
@@ -108,10 +108,25 @@ namespace MinVer.Lib
                 ? this
                 : new Version(minMajorMinor.Major, minMajorMinor.Minor, default, new[] { "alpha", "0" }, this.height, this.buildMetadata);
 
-        public Version WithHeight(int height) =>
-            this.preReleaseIdentifiers.Count == 0 && height > 0
-                ? new Version(this.Major, this.Minor, this.Patch + 1, new[] { "alpha", "0" }, height, default)
-                : new Version(this.Major, this.Minor, this.Patch, this.preReleaseIdentifiers, height, height == 0 ? this.buildMetadata : default);
+        public Version WithHeight(int height, VersionPart autoIncrement)
+        {
+            if (this.preReleaseIdentifiers.Count == 0 && height > 0)
+            {
+                switch (autoIncrement)
+                {
+                    case VersionPart.Major:
+                        return new Version(this.Major + 1, 0, 0, new[] { "alpha", "0" }, height, default);
+                    case VersionPart.Minor:
+                        return new Version(this.Major, this.Minor + 1, 0, new[] { "alpha", "0" }, height, default);
+                    case VersionPart.Patch:
+                        return new Version(this.Major, this.Minor, this.Patch + 1, new[] { "alpha", "0" }, height, default);
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(autoIncrement));
+                }
+            }
+
+            return new Version(this.Major, this.Minor, this.Patch, this.preReleaseIdentifiers, height, height == 0 ? this.buildMetadata : default);
+        }
 
         public Version AddBuildMetadata(string buildMetadata)
         {

--- a/MinVer.Lib/VersionPart.cs
+++ b/MinVer.Lib/VersionPart.cs
@@ -1,0 +1,14 @@
+namespace MinVer.Lib
+{
+    public enum VersionPart
+    {
+        Patch = 0,
+        Minor = 1,
+        Major = 2,
+    }
+
+    public static class VersionPartExtensions
+    {
+        public static string GetValidValues(this VersionPart versionPart) => "major, minor, or patch (default)";
+    }
+}

--- a/MinVer.Lib/Versioner.cs
+++ b/MinVer.Lib/Versioner.cs
@@ -2,9 +2,9 @@ namespace MinVer.Lib
 {
     public static class Versioner
     {
-        public static Version GetVersion(string repoOrWorkDir, string tagPrefix, MajorMinor minMajorMinor, string buildMeta, ILogger log)
+        public static Version GetVersion(string repoOrWorkDir, string tagPrefix, MajorMinor minMajorMinor, string buildMeta, VersionPart autoIncrement, ILogger log)
         {
-            var version = GetVersion(repoOrWorkDir, tagPrefix, log).AddBuildMetadata(buildMeta);
+            var version = GetVersion(repoOrWorkDir, tagPrefix, autoIncrement, log).AddBuildMetadata(buildMeta);
 
             var calculatedVersion = version.Satisfying(minMajorMinor);
 
@@ -25,7 +25,7 @@ namespace MinVer.Lib
             return calculatedVersion;
         }
 
-        private static Version GetVersion(string repoOrWorkDir, string tagPrefix, ILogger log)
+        private static Version GetVersion(string repoOrWorkDir, string tagPrefix, VersionPart autoIncrement, ILogger log)
         {
             if (!RepositoryEx.TryCreateRepo(repoOrWorkDir, out var repo))
             {
@@ -38,7 +38,7 @@ namespace MinVer.Lib
 
             try
             {
-                return repo.GetVersion(tagPrefix, log);
+                return repo.GetVersion(tagPrefix, autoIncrement, log);
             }
             finally
             {

--- a/MinVer/Logger.cs
+++ b/MinVer/Logger.cs
@@ -48,6 +48,9 @@ namespace MinVer
         public static void ErrorRepoOrWorkDirDoesNotExist(string repoOrWorkDir) =>
             Error(1002, $"Repository or working directory '{repoOrWorkDir}' does not exist.");
 
+        public static void ErrorInvalidAutoIncrement(string autoIncrement) =>
+            Error(1006, $"Invalid auto increment '{autoIncrement}'. Valid values are {VersionPart.Patch.GetValidValues()}");
+
         public static void ErrorInvalidMinMajorMinor(string minMajorMinor) =>
             Error(1003, $"Invalid minimum MAJOR.MINOR '{minMajorMinor}'. Valid values are {MajorMinor.ValidValues}");
 

--- a/MinVer/build/MinVer.targets
+++ b/MinVer/build/MinVer.targets
@@ -14,6 +14,7 @@
   <Target Name="MinVer" BeforeTargets="CoreCompile;GenerateNuspec" Condition="'$(DesignTimeBuild)' != 'true'">
     <Error Condition="'$(UsingMicrosoftNETSdk)' != 'true'" Code="MINVER0001" Text="MinVer only works in SDK-style projects." />
     <Error Condition="'$(MinVerMajorMinor)' != ''" Code="MINVER_TEMP0001" Text="MinVerMajorMinor has been renamed to MinVerMinimumMajorMinor." />
+    <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MinVerAutoIncrement=$(MinVerAutoIncrement)" />
     <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MinVerBuildMetadata=$(MinVerBuildMetadata)" />
     <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MinVerMinimumMajorMinor=$(MinVerMinimumMajorMinor)" />
     <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MSBuildProjectDirectory=$(MSBuildProjectDirectory)" />
@@ -26,6 +27,7 @@
       <MinVerOutputVersion Remove="@(MinVerOutputVersion)" />
     </ItemGroup>
     <ItemGroup>
+      <MinVerInputs Include="--auto-increment &quot;$(MinVerAutoIncrement)&quot;" />
       <MinVerInputs Include="--build-metadata &quot;$(MinVerBuildMetadata)&quot;" />
       <MinVerInputs Include="--minimum-major-minor &quot;$(MinVerMinimumMajorMinor)&quot;" />
       <MinVerInputs Include="--repo &quot;$(MSBuildProjectDirectory)&quot;" />

--- a/MinVerTests/AutoIncrement.cs
+++ b/MinVerTests/AutoIncrement.cs
@@ -1,0 +1,36 @@
+namespace MinVerTests
+{
+    using LibGit2Sharp;
+    using MinVer.Lib;
+    using MinVerTests.Infra;
+    using Xbehave;
+    using Xunit;
+    using static MinVerTests.Infra.FileSystem;
+    using static MinVerTests.Infra.Git;
+    using Version = MinVer.Lib.Version;
+
+    public static class AutoIncrement
+    {
+        [Scenario]
+        [Example("1.2.3", VersionPart.Major, "2.0.0-alpha.0.1")]
+        [Example("1.2.3", VersionPart.Minor, "1.3.0-alpha.0.1")]
+        [Example("1.2.3", VersionPart.Patch, "1.2.4-alpha.0.1")]
+        public static void RtmVersionIncrement(string tag, VersionPart autoIncrement, string expectedVersion, string path, Repository repo, Version actualVersion)
+        {
+            $"Given a git repository with a commit in '{path = GetScenarioDirectory($"rtm-auto-increment-{tag}")}'"
+                .x(c => repo = EnsureEmptyRepositoryAndCommit(path).Using(c));
+
+            $"And the commit is tagged '{tag}'"
+                .x(() => repo.ApplyTag(tag));
+
+            $"And another commit"
+                .x(() => Commit(path));
+
+            $"When the version is determined using auto-increment '{autoIncrement}'"
+                .x(() => actualVersion = Versioner.GetVersion(path, default, default, default, autoIncrement, new TestLogger()));
+
+            $"Then the version is '{expectedVersion}'"
+                .x(() => Assert.Equal(expectedVersion, actualVersion.ToString()));
+        }
+    }
+}

--- a/MinVerTests/BuildMetadata.cs
+++ b/MinVerTests/BuildMetadata.cs
@@ -20,7 +20,7 @@ namespace MinVerTests
                 .x(c => EnsureEmptyRepository(path).Using(c));
 
             $"When the version is determined using build metadata '{buildMetadata}'"
-                .x(() => actualVersion = Versioner.GetVersion(path, default, default, buildMetadata, new TestLogger()));
+                .x(() => actualVersion = Versioner.GetVersion(path, default, default, buildMetadata, default, new TestLogger()));
 
             $"Then the version is '{expectedVersion}'"
                 .x(() => Assert.Equal(expectedVersion, actualVersion.ToString()));
@@ -35,7 +35,7 @@ namespace MinVerTests
                 .x(c => EnsureEmptyRepositoryAndCommit(path).Using(c));
 
             $"When the version is determined using build metadata '{buildMetadata}'"
-                .x(() => actualVersion = Versioner.GetVersion(path, default, default, buildMetadata, new TestLogger()));
+                .x(() => actualVersion = Versioner.GetVersion(path, default, default, buildMetadata, default, new TestLogger()));
 
             $"Then the version is '{expectedVersion}'"
                 .x(() => Assert.Equal(expectedVersion, actualVersion.ToString()));
@@ -57,7 +57,7 @@ namespace MinVerTests
                 .x(() => repo.ApplyTag(tag));
 
             $"When the version is determined using build metadata '{buildMetadata}'"
-                .x(() => actualVersion = Versioner.GetVersion(path, default, default, buildMetadata, new TestLogger()));
+                .x(() => actualVersion = Versioner.GetVersion(path, default, default, buildMetadata, default, new TestLogger()));
 
             $"Then the version is '{expectedVersion}'"
                 .x(() => Assert.Equal(expectedVersion, actualVersion.ToString()));
@@ -82,7 +82,7 @@ namespace MinVerTests
                 .x(() => Commit(path));
 
             $"When the version is determined using build metadata '{buildMetadata}'"
-                .x(() => actualVersion = Versioner.GetVersion(path, default, default, buildMetadata, new TestLogger()));
+                .x(() => actualVersion = Versioner.GetVersion(path, default, default, buildMetadata, default, new TestLogger()));
 
             $"Then the version is '{expectedVersion}'"
                 .x(() => Assert.Equal(expectedVersion, actualVersion.ToString()));

--- a/MinVerTests/MinMajorMinor.cs
+++ b/MinVerTests/MinMajorMinor.cs
@@ -18,7 +18,7 @@ namespace MinVerTests
                 .x(c => EnsureEmptyRepository(path).Using(c));
 
             "When the version is determined using minimum major minor '1.2'"
-                .x(() => actualVersion = Versioner.GetVersion(path, default, new MajorMinor(1, 2), default, new TestLogger()));
+                .x(() => actualVersion = Versioner.GetVersion(path, default, new MajorMinor(1, 2), default, default, new TestLogger()));
 
             $"Then the version is '1.2.0-alpha.0'"
                 .x(() => Assert.Equal("1.2.0-alpha.0", actualVersion.ToString()));
@@ -37,7 +37,7 @@ namespace MinVerTests
                 .x(() => repo.ApplyTag(tag));
 
             $"When the version is determined using minimum major minor '{major}.{minor}'"
-                .x(() => actualVersion = Versioner.GetVersion(path, default, new MajorMinor(major, minor), default, logger = new TestLogger()));
+                .x(() => actualVersion = Versioner.GetVersion(path, default, new MajorMinor(major, minor), default, default, logger = new TestLogger()));
 
             $"Then the version is '{expectedVersion}'"
                 .x(() => Assert.Equal(expectedVersion, actualVersion.ToString()));
@@ -56,7 +56,7 @@ namespace MinVerTests
                 .x(c => EnsureEmptyRepositoryAndCommit(path).Using(c));
 
             "When the version is determined using minimum major minor '1.0'"
-                .x(() => actualVersion = Versioner.GetVersion(path, default, new MajorMinor(1, 0), default, new TestLogger()));
+                .x(() => actualVersion = Versioner.GetVersion(path, default, new MajorMinor(1, 0), default, default, new TestLogger()));
 
             $"Then the version is '1.0.0-alpha.0'"
                 .x(() => Assert.Equal("1.0.0-alpha.0", actualVersion.ToString()));

--- a/MinVerTests/TagPrefixes.cs
+++ b/MinVerTests/TagPrefixes.cs
@@ -25,7 +25,7 @@ namespace MinVerTests
                 .x(() => repo.ApplyTag(tag));
 
             $"When the version is determined using the tag prefix '{prefix}'"
-                .x(() => actualVersion = Versioner.GetVersion(path, prefix, default, default, new TestLogger()));
+                .x(() => actualVersion = Versioner.GetVersion(path, prefix, default, default, default, new TestLogger()));
 
             $"Then the version is '{expectedVersion}'"
                 .x(() => Assert.Equal(expectedVersion, actualVersion.ToString()));

--- a/MinVerTests/Versioning.cs
+++ b/MinVerTests/Versioning.cs
@@ -93,7 +93,7 @@ git tag 1.1.0
                     {
                         Commands.Checkout(repo, commit);
 
-                        var version = Versioner.GetVersion(path, default, default, default, new TestLogger());
+                        var version = Versioner.GetVersion(path, default, default, default, default, new TestLogger());
                         var versionString = version.ToString();
                         var tagName = $"v/{versionString}";
 
@@ -125,7 +125,7 @@ git tag 1.1.0
                 .x(c => EnsureEmptyRepository(path).Using(c));
 
             "When the version is determined"
-                .x(() => version = Versioner.GetVersion(path, default, default, default, new TestLogger()));
+                .x(() => version = Versioner.GetVersion(path, default, default, default, default, new TestLogger()));
 
             "Then the version is 0.0.0-alpha.0"
                 .x(() => Assert.Equal("0.0.0-alpha.0", version.ToString()));

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ _NOTE: The MinVer package reference should normally include `PrivateAssets="All"
 
 When the current commit is tagged with a version, the tag is used as-is.
 
-When the current commit is not tagged, MinVer searches the commit history for the latest tag. If the latest tag found is a [pre-release](https://semver.org/spec/v2.0.0.html#spec-item-9), MinVer will use it as-is. If the latest tag found is RTM (not pre-release), MinVer will increase the patch number and add default pre-release identifiers, e.g. `1.0.0` becomes `1.0.1-alpha.0`. If no tag is found, the default version `0.0.0-alpha.0` is used.
+When the current commit is _not_ tagged, MinVer searches the commit history for the latest tag. If the latest tag found is a [pre-release](https://semver.org/spec/v2.0.0.html#spec-item-9), MinVer will use it as-is. If the latest tag found is RTM (not pre-release), MinVer will add default pre-release identifiers. MinVer will also increase the patch number, although this behaviour [can be customised](#can-i-auto-increment-the-minor-or-major-version-after-an-rtm-tag-instead-of-the-patch-version). For example, If the latest tag is `1.0.0`, the current version will be `1.0.1-alpha.0`.
+
+If no tag is found either on the current commit or in the commit history, the default version `0.0.0-alpha.0` is used.
 
 You will notice that MinVer adds another number to the pre-release identifiers when the current commit is not tagged. This is the number of commits since the latest tag, or if no tag was found, since the root commit. This is known as "height". For example, if the latest tag found is `1.0.0-beta.1`, at a height of 42 commits, the calculated version is `1.0.0-beta.1.42`.
 
@@ -72,6 +74,7 @@ This behaviour can be [customised](#can-i-use-the-version-calculated-by-minver-f
 
 Options can be specified as either MSBuild properties or environment variables.
 
+- [`MinVerAutoIncrement`](#can-i-auto-increment-the-minor-or-major-version-after-an-rtm-tag-instead-of-the-patch-version)
 - [`MinVerBuildMetadata`](#can-i-include-build-metadata-in-the-version)
 - [`MinVerMinimumMajorMinor`](#can-i-bump-the-major-or-minor-version)
 - [`MinVerTagPrefix`](#can-i-prefix-my-tag-names)
@@ -89,6 +92,7 @@ _(With TL;DR answers inline.)_
 - [Can I prefix my tag names?](#can-i-prefix-my-tag-names) _(yes)_
 - [Can I use my own branching strategy?](#can-i-use-my-own-branching-strategy) _(yes)_
 - [Can I include build metadata in the version?](#can-i-include-build-metadata-in-the-version) _(yes)_
+- [Can I auto-increment the minor or major version after an RTM tag instead of the patch version?](#can-i-auto-increment-the-minor-or-major-version-after-an-rtm-tag-instead-of-the-patch-version) _(yes)_
 - [Can I use the version calculated by MinVer for other purposes?](#can-i-use-the-version-calculated-by-minver-for-other-purposes) _(yes)_
 - [Can I version multiple projects in a single repo independently?](#can-i-version-multiple-projects-in-a-single-repo-independently) _(yes)_
 - [Can I get log output to see how MinVer calculates the version?](#can-i-get-log-output-to-see-how-minver-calculates-the-version) _(yes)_
@@ -159,6 +163,10 @@ environment:
 ```
 
 You can also specify build metadata in a version tag. If the tag is on the current commit, its build metadata will be used. If the tag is on an older commit, its build metadata will be ignored. Build metadata in `MinVerBuildMetadata` will be appended to build metadata in the tag.
+
+### Can I auto-increment the minor or major version after an RTM tag instead of the patch version?
+
+Yes! Specify which part of the version to auto-increment with `MinVerAutoIncrement`. By default, [MinVer will auto-increment the patch version](#how-it-works), but you can specify `minor` or `major` to increment the minor or major version instead.
 
 ### Can I use the version calculated by MinVer for other purposes?
 

--- a/minver-cli/Logger.cs
+++ b/minver-cli/Logger.cs
@@ -48,6 +48,9 @@ namespace MinVer
         public static void ErrorRepoOrWorkDirDoesNotExist(string repoOrWorkDir) =>
             Error($"Repository or working directory '{repoOrWorkDir}' does not exist.");
 
+        public static void ErrorInvalidAutoIncrement(string autoIncrement) =>
+            Error($"Invalid auto increment '{autoIncrement}'. Valid values are {VersionPart.Patch.GetValidValues()}");
+
         public static void ErrorInvalidMinMajorMinor(string minMajorMinor) =>
             Error($"Invalid minimum MAJOR.MINOR '{minMajorMinor}'. Valid values are {MajorMinor.ValidValues}");
 

--- a/targets/Program.cs
+++ b/targets/Program.cs
@@ -166,8 +166,28 @@ internal static class Program
             });
 
         Target(
-            "test-package-minimum-major-minor",
+            "test-package-non-default-auto-increment",
             DependsOn("test-package-commit-after-tag"),
+            async () =>
+            {
+                using (var repo = new Repository(testRepo))
+                {
+                    // arrange
+                    Environment.SetEnvironmentVariable("MinVerAutoIncrement", "minor", EnvironmentVariableTarget.Process);
+
+                    var output = Path.Combine(testPackageBaseOutput, $"{buildNumber}-test-package-non-default-auto-increment");
+
+                    // act
+                    await CleanAndPack(testRepo, output, "diagnostic");
+
+                    // assert
+                    AssertPackageFileNameContains("1.3.0-alpha.0.1.nupkg", output);
+                }
+            });
+
+        Target(
+            "test-package-minimum-major-minor",
+            DependsOn("test-package-non-default-auto-increment"),
             async () =>
             {
                 using (var repo = new Repository(testRepo))


### PR DESCRIPTION
The when applying minver, a user should be able to override the default
behavior of how versions are incremented. The current behavior is, that
whenever minver is run on a commit, that does not carry a minver tag and
is at a height > 0 from the last minver tag, the patch version will be
incremented and the height added. For example: When the latest tag is
1.2.3 and the commit is at a height of 1 from this tag, the resolved
version will be 1.2.4-alpha.0.1.

This behavior should be customizable by setting a property that defines
what segments of the version (major, minor, patch) should be
incremented.

Closes #212