### PR TITLE
Clear ItemGroups before using them

### DIFF
--- a/MinVer/build/MinVer.targets
+++ b/MinVer/build/MinVer.targets
@@ -21,6 +21,11 @@
     <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MinVerVerbosity=$(MinVerVerbosity)" />
     <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MinVerVersionOverride=$(MinVerVersionOverride)" />
     <ItemGroup>
+      <MinVerInputs Remove="@(MinVerInputs)" />
+      <MinVerConsoleOutput Remove="@(MinVerConsoleOutput)" />
+      <MinVerOutputVersion Remove="@(MinVerOutputVersion)" />
+    </ItemGroup>
+    <ItemGroup>
       <MinVerInputs Include="--build-metadata &quot;$(MinVerBuildMetadata)&quot;" />
       <MinVerInputs Include="--minimum-major-minor &quot;$(MinVerMinimumMajorMinor)&quot;" />
       <MinVerInputs Include="--repo &quot;$(MSBuildProjectDirectory)&quot;" />


### PR DESCRIPTION
Fixes #217 

I was originally going to put the `Remove` next to the first `Include` for each group, but that doesn't work for `MinVerConsoleOutput`, so I decided to add a dedicated group just for the `Remove`s instead.