### PR TITLE
Make $(MinVerPreRelease) predominant in PR example

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ For example, for pull requests, you may want to inject the pull request number a
 ```xml
 <Target Name="MyTarget" AfterTargets="MinVer" Condition="'$(APPVEYOR_PULL_REQUEST_NUMBER)' != ''" >
   <PropertyGroup>
-    <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-pr.$(APPVEYOR_PULL_REQUEST_NUMBER).build-id.$(APPVEYOR_BUILD_ID).$(MinVerPreRelease)</PackageVersion>
+    <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-$(MinVerPreRelease).pr.$(APPVEYOR_PULL_REQUEST_NUMBER).build-id.$(APPVEYOR_BUILD_ID)</PackageVersion>
     <PackageVersion Condition="'$(MinVerBuildMetadata)' != ''">$(PackageVersion)+$(MinVerBuildMetadata)</PackageVersion>
     <Version>$(PackageVersion)</Version>
   </PropertyGroup>


### PR DESCRIPTION
When using AppVeyor (or any CI/CD) to generate packages for PR the currently suggested package ID schema makes so that PR related packages appear as more recent than non-PR related packages.

Currently the [suggested schema](https://github.com/adamralph/minver#can-i-use-the-version-calculated-by-minver-for-other-purposes) is:

```
<Target Name="MyTarget" AfterTargets="MinVer" Condition="'$(APPVEYOR_PULL_REQUEST_NUMBER)' != ''" >
  <PropertyGroup>
    <PackageVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch)-pr.$(APPVEYOR_PULL_REQUEST_NUMBER).build-id.$(APPVEYOR_BUILD_ID).$(MinVerPreRelease)</PackageVersion>
    <PackageVersion Condition="'$(MinVerBuildMetadata)' != ''">$(PackageVersion)+$(MinVerBuildMetadata)</PackageVersion>
    <Version>$(PackageVersion)</Version>
  </PropertyGroup>
</Target>
```

using the above approach would result in packages whose id is for example `mypackage.1.0.0-pr.123.build.id.12345678.Beta.1`. When such a PR is merged if the repo is tagged as 1.0.0-Beta.1, which makes sense IMO, the resulting package id will be `mypackage.1.0.0-Beta.1` which is, from the sorting perspective, smaller than the one in the PR. Making so that on package managers, such as Nuget or MyGet, the PR package will always display as the latest version.

Am I missing something obvious or is my proposal a solution to the mentioned issue?