### PR TITLE
Simpler and more accurate exception message when git is not present in PATH

### DIFF
--- a/MinVer.Lib/GitCommand.cs
+++ b/MinVer.Lib/GitCommand.cs
@@ -33,7 +33,7 @@ namespace MinVer.Lib
                 }
                 catch (Win32Exception ex)
                 {
-                    throw new Exception("Failed to run Git. Git may not be installed on the system.", ex);
+                    throw new Exception("\"git\" is not present in PATH.", ex);
                 }
 
                 var runProcess = tcs.Task;


### PR DESCRIPTION
When `GitCommand` fails on macOS it is really confusing. Changed
it to an `IOException` with a more precise error message. Cross-Platform
for the win!

 #318