### PR TITLE
Add more BeforeTargets to MinVer target

### DIFF
--- a/MinVer/build/MinVer.targets
+++ b/MinVer/build/MinVer.targets
@@ -11,7 +11,7 @@
     <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
 
-  <Target Name="MinVer" BeforeTargets="CoreCompile;GenerateNuspec" Condition="'$(DesignTimeBuild)' != 'true' AND '$(MinVerSkip)' != 'true'">
+  <Target Name="MinVer" BeforeTargets="BeforeCompile;GetAssemblyVersion;CoreCompile;GenerateNuspec" Condition="'$(DesignTimeBuild)' != 'true' AND '$(MinVerSkip)' != 'true'">
     <Error Condition="'$(UsingMicrosoftNETSdk)' != 'true'" Code="MINVER0001" Text="MinVer only works in SDK-style projects." />
     <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MinVerAutoIncrement=$(MinVerAutoIncrement)" />
     <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MinVerBuildMetadata=$(MinVerBuildMetadata)" />


### PR DESCRIPTION
https://github.com/dotnet/sdk/pull/10613 made a change to the `GenerateAssemblyInfo` target to fix  a [problem](https://github.com/dotnet/sdk/issues/10614) related to Source Link.

This change ensures that the `MinVer` target is called early enough to get the version values populated before `GenerateAssemblyInfo` writes them to disk in the generated `AssemblyInfo.cs` file.

Fixes #343