### PR TITLE
Support .NET Core SDK 3.1.300 and later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/setup-dotnet@b7821147f564527086410e8edd122d89b4b9602f
       with:
-        dotnet-version: '3.1.102'
+        dotnet-version: '3.1.300'
     - run: dotnet --info
     - uses: actions/checkout@af513c7a016048ae468971c52ed77d9562c7c819
     - if: contains(matrix.runs-on, 'windows')

--- a/MinVer/build/MinVer.targets
+++ b/MinVer/build/MinVer.targets
@@ -11,7 +11,7 @@
     <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
 
-  <Target Name="MinVer" BeforeTargets="CoreCompile;GenerateNuspec" Condition="'$(DesignTimeBuild)' != 'true' AND '$(MinVerSkip)' != 'true'">
+  <Target Name="MinVer" BeforeTargets="BeforeCompile;GetAssemblyVersion;CoreCompile;GenerateNuspec" Condition="'$(DesignTimeBuild)' != 'true' AND '$(MinVerSkip)' != 'true'">
     <Error Condition="'$(UsingMicrosoftNETSdk)' != 'true'" Code="MINVER0001" Text="MinVer only works in SDK-style projects." />
     <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MinVerAutoIncrement=$(MinVerAutoIncrement)" />
     <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MinVerBuildMetadata=$(MinVerBuildMetadata)" />

--- a/targets/Program.cs
+++ b/targets/Program.cs
@@ -57,7 +57,7 @@ internal static class Program
                     Path.Combine(testProject, "global.json"),
 @"{
   ""sdk"": {
-    ""version"": ""3.1.102""
+    ""version"": ""3.1.300""
   }
 }
 "

--- a/targets/Program.cs
+++ b/targets/Program.cs
@@ -50,6 +50,16 @@ internal static class Program
                 var source = Path.GetFullPath("./MinVer/bin/Release/");
                 var version = Path.GetFileNameWithoutExtension(Directory.EnumerateFiles(source, "*.nupkg").First()).Split("MinVer.", 2)[1];
 
+                File.WriteAllText(
+                    Path.Combine(testProject, "global.json"),
+@"{
+  ""sdk"": {
+    ""version"": ""3.1.102""
+  }
+}
+"
+                    );
+
                 await RunAsync("dotnet", "new classlib", testProject);
                 await RunAsync("dotnet", $"add package MinVer --source {source} --version {version} --package-directory packages", testProject);
                 await RunAsync("dotnet", $"restore --source {source} --packages packages", testProject);

--- a/targets/Program.cs
+++ b/targets/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Xunit;
 using static Bullseye.Targets;
 using static MinVerTests.Infra.FileSystem;
 using static MinVerTests.Infra.Git;
@@ -66,7 +67,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic");
 
                 // assert
-                AssertPackageFileNameContains("0.0.0-alpha.0.nupkg", output);
+                AssertVersion("0.0.0-alpha.0", output);
             });
 
         Target(
@@ -83,7 +84,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic");
 
                 // assert
-                AssertPackageFileNameContains("0.0.0-alpha.0.nupkg", output);
+                AssertVersion("0.0.0-alpha.0", output);
             });
 
         Target(
@@ -101,7 +102,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic");
 
                 // assert
-                AssertPackageFileNameContains("0.0.0-alpha.0.nupkg", output);
+                AssertVersion("0.0.0-alpha.0", output);
             });
 
         Target(
@@ -118,7 +119,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic");
 
                 // assert
-                AssertPackageFileNameContains("0.0.0-alpha.0.nupkg", output);
+                AssertVersion("0.0.0-alpha.0", output);
             });
 
         Target(
@@ -135,7 +136,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "normal", env => env.Add("MinVerTagPrefix", "v."));
 
                 // assert
-                AssertPackageFileNameContains("1.2.3.nupkg", output);
+                AssertVersion("1.2.3", output);
             });
 
         Target(
@@ -153,7 +154,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "detailed");
 
                 // assert
-                AssertPackageFileNameContains("1.2.4-alpha.0.1.nupkg", output);
+                AssertVersion("1.2.4-alpha.0.1", output);
             });
 
         Target(
@@ -168,7 +169,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic", env => env.Add("MinVerAutoIncrement", "minor"));
 
                 // assert
-                AssertPackageFileNameContains("1.3.0-alpha.0.1.nupkg", output);
+                AssertVersion("1.3.0-alpha.0.1", output);
             });
 
         Target(
@@ -185,7 +186,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic");
 
                 // assert
-                AssertPackageFileNameContains("1.4.0.nupkg", output);
+                AssertVersion("1.4.0", output);
             });
 
         Target(
@@ -203,7 +204,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic", env => env.Add("MinVerMinimumMajorMinor", "2.0"));
 
                 // assert
-                AssertPackageFileNameContains("2.0.0-alpha.0.nupkg", output);
+                AssertVersion("2.0.0-alpha.0", output);
             });
 
         Target(
@@ -220,7 +221,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic", env => env.Add("MinVerMinimumMajorMinor", "2.0"));
 
                 // assert
-                AssertPackageFileNameContains("2.0.0-alpha.0.1.nupkg", output);
+                AssertVersion("2.0.0-alpha.0.1", output);
             });
 
         Target(
@@ -235,7 +236,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic", env => env.Add("MinVerDefaultPreReleasePhase", "preview"));
 
                 // assert
-                AssertPackageFileNameContains("1.5.1-preview.0.1.nupkg", output);
+                AssertVersion("1.5.1-preview.0.1", output);
             });
 
         Target(
@@ -250,7 +251,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic", env => env.Add("MinVerVersionOverride", "3.2.1-rc.4+build.5"));
 
                 // assert
-                AssertPackageFileNameContains("3.2.1-rc.4.nupkg", output);
+                AssertVersion("3.2.1-rc.4", output);
             });
 
         Target("test-package", DependsOn("test-package-version-override"));
@@ -276,14 +277,11 @@ internal static class Program
             });
     }
 
-    private static void AssertPackageFileNameContains(string expected, string path)
+    private static void AssertVersion(string expected, string path)
     {
         var fileName = Directory.EnumerateFiles(path, "*.nupkg", new EnumerationOptions { RecurseSubdirectories = true })
             .First();
 
-        if (!fileName.Contains(expected))
-        {
-            throw new Exception($"'{fileName}' does not contain '{expected}'.");
-        }
+        Assert.EndsWith(expected, Path.GetFileNameWithoutExtension(fileName));
     }
 }

--- a/targets/Program.cs
+++ b/targets/Program.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
+using System.Runtime.Loader;
 using System.Threading.Tasks;
 using Xunit;
 using static Bullseye.Targets;
@@ -77,7 +80,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic");
 
                 // assert
-                AssertVersion("0.0.0-alpha.0", output);
+                AssertVersion(new Version(0, 0, 0, new[] { "alpha", "0" }), output);
             });
 
         Target(
@@ -94,7 +97,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic");
 
                 // assert
-                AssertVersion("0.0.0-alpha.0", output);
+                AssertVersion(new Version(0, 0, 0, new[] { "alpha", "0" }), output);
             });
 
         Target(
@@ -112,7 +115,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic");
 
                 // assert
-                AssertVersion("0.0.0-alpha.0", output);
+                AssertVersion(new Version(0, 0, 0, new[] { "alpha", "0" }), output);
             });
 
         Target(
@@ -129,7 +132,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic");
 
                 // assert
-                AssertVersion("0.0.0-alpha.0", output);
+                AssertVersion(new Version(0, 0, 0, new[] { "alpha", "0" }), output);
             });
 
         Target(
@@ -146,7 +149,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "normal", env => env.Add("MinVerTagPrefix", "v."));
 
                 // assert
-                AssertVersion("1.2.3", output);
+                AssertVersion(new Version(1, 2, 3, default, default, "foo"), output);
             });
 
         Target(
@@ -164,7 +167,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "detailed");
 
                 // assert
-                AssertVersion("1.2.4-alpha.0.1", output);
+                AssertVersion(new Version(1, 2, 4, new[] { "alpha", "0" }, 1), output);
             });
 
         Target(
@@ -179,7 +182,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic", env => env.Add("MinVerAutoIncrement", "minor"));
 
                 // assert
-                AssertVersion("1.3.0-alpha.0.1", output);
+                AssertVersion(new Version(1, 3, 0, new[] { "alpha", "0" }, 1), output);
             });
 
         Target(
@@ -196,7 +199,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic");
 
                 // assert
-                AssertVersion("1.4.0", output);
+                AssertVersion(new Version(1, 4, 0), output);
             });
 
         Target(
@@ -214,7 +217,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic", env => env.Add("MinVerMinimumMajorMinor", "2.0"));
 
                 // assert
-                AssertVersion("2.0.0-alpha.0", output);
+                AssertVersion(new Version(2, 0, 0, new[] { "alpha", "0" }), output);
             });
 
         Target(
@@ -231,7 +234,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic", env => env.Add("MinVerMinimumMajorMinor", "2.0"));
 
                 // assert
-                AssertVersion("2.0.0-alpha.0.1", output);
+                AssertVersion(new Version(2, 0, 0, new[] { "alpha", "0" }, 1), output);
             });
 
         Target(
@@ -246,7 +249,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic", env => env.Add("MinVerDefaultPreReleasePhase", "preview"));
 
                 // assert
-                AssertVersion("1.5.1-preview.0.1", output);
+                AssertVersion(new Version(1, 5, 1, new[] { "preview", "0" }, 1), output);
             });
 
         Target(
@@ -261,7 +264,7 @@ internal static class Program
                 await CleanAndPack(testProject, output, "diagnostic", env => env.Add("MinVerVersionOverride", "3.2.1-rc.4+build.5"));
 
                 // assert
-                AssertVersion("3.2.1-rc.4", output);
+                AssertVersion(new Version(3, 2, 1, new[] { "rc", "4" }, default, "build.5"), output);
             });
 
         Target("test-package", DependsOn("test-package-version-override"));
@@ -287,11 +290,61 @@ internal static class Program
             });
     }
 
-    private static void AssertVersion(string expected, string path)
+    private static void AssertVersion(Version expected, string path)
     {
-        var fileName = Directory.EnumerateFiles(path, "*.nupkg", new EnumerationOptions { RecurseSubdirectories = true })
+        var packagePath = Directory.EnumerateFiles(path, "*.nupkg", new EnumerationOptions { RecurseSubdirectories = true })
             .First();
 
-        Assert.EndsWith(expected, Path.GetFileNameWithoutExtension(fileName));
+        Assert.EndsWith(expected.ToString().Split('+')[0], Path.GetFileNameWithoutExtension(packagePath));
+
+        ZipFile.ExtractToDirectory(
+            packagePath,
+            Path.Combine(Path.GetDirectoryName(packagePath), Path.GetFileNameWithoutExtension(packagePath)));
+
+        var assemblyPath = Directory.EnumerateFiles(path, "*.dll", new EnumerationOptions { RecurseSubdirectories = true })
+            .First();
+
+        var context = new AssemblyLoadContext(default, true);
+        var assembly = context.LoadFromAssemblyPath(assemblyPath);
+        var assemblyVersion = assembly.GetName().Version;
+        context.Unload();
+
+        var fileVersion = FileVersionInfo.GetVersionInfo(assemblyPath);
+
+        Assert.Equal(expected.Major, assemblyVersion.Major);
+        Assert.Equal(0, assemblyVersion.Minor);
+        Assert.Equal(0, assemblyVersion.Build);
+
+        Assert.Equal(expected.Major, fileVersion.FileMajorPart);
+        Assert.Equal(expected.Minor, fileVersion.FileMinorPart);
+        Assert.Equal(expected.Patch, fileVersion.FileBuildPart);
+
+        Assert.Equal(expected.ToString(), fileVersion.ProductVersion);
+    }
+
+    public class Version
+    {
+        private readonly List<string> preReleaseIdentifiers;
+        private readonly int height;
+        private readonly string buildMetadata;
+
+        public Version(int major, int minor, int patch, IEnumerable<string> preReleaseIdentifiers = null, int height = 0, string buildMetadata = null)
+        {
+            this.Major = major;
+            this.Minor = minor;
+            this.Patch = patch;
+            this.preReleaseIdentifiers = preReleaseIdentifiers?.ToList() ?? new List<string>();
+            this.height = height;
+            this.buildMetadata = buildMetadata;
+        }
+
+        public int Major { get; }
+
+        public int Minor { get; }
+
+        public int Patch { get; }
+
+        public override string ToString() =>
+            $"{this.Major}.{this.Minor}.{this.Patch}{(this.preReleaseIdentifiers.Count == 0 ? "" : $"-{string.Join(".", this.preReleaseIdentifiers)}")}{(this.height == 0 ? "" : $".{this.height}")}{(string.IsNullOrEmpty(this.buildMetadata) ? "" : $"+{this.buildMetadata}")}";
     }
 }

--- a/targets/Targets.csproj
+++ b/targets/Targets.csproj
@@ -14,6 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Bullseye" Version="3.3.0" />
     <PackageReference Include="SimpleExec" Version="6.2.0" />
+    <PackageReference Include="xunit.assert" Version="2.4.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
.NET Core SDK 3.1.300 contains a [breaking change](https://github.com/dotnet/sdk/issues/10614) which results in projects versioned with MinVer producing assemblies which do not have the correct `AssemblyFileVersion`, `AssemblyInformationalVersion`, and `AssemblyVersion`. This effectively means that MinVer 2.2.0 and earlier do not support .NET Core SDK 3.1.300.

This enhancement adds support for .NET Core SDK 3.1.300 and later.

Thanks to @ghorsey and @joacar for spotting this and raising #342 and #343 respectively, and thanks to @bording for fixing this in https://github.com/adamralph/minver/pull/344, which was cherry-picked into this branch.