### PR TITLE
CLI output has new line terminator(s)

### DIFF
--- a/minver-cli/Program.cs
+++ b/minver-cli/Program.cs
@@ -62,7 +62,7 @@ namespace MinVer
                 var version = Versioner.GetVersion(workDir, tagPrefixOption.Value(), minMajorMinor, buildMetaOption.Value(), autoIncrement, defaultPreReleasePhaseOption.Value(), log);
 #endif
 
-                    Console.Out.WriteLine(version);
+                    Console.Out.Write(version);
 
                     return 0;
                 });


### PR DESCRIPTION
Can cause problems when parsing the output. For example, using the `semver` package:

```c#
var versionString = SimpleExec.Command.Read("minver");
var version = Semver.SemVersion.Parse(versionString);
```

This results in an "Invalid version" exception.

The version needs to be trimmed first:

```c#
var versionString = SimpleExec.Command.Read("minver").Trim();
var version = Semver.SemVersion.Parse(versionString);
```
