### PR TITLE
Ignore 'root commits' created by subtree add 

### DIFF
--- a/MinVer.Lib/Commit.cs
+++ b/MinVer.Lib/Commit.cs
@@ -10,7 +10,8 @@ namespace MinVer.Lib
 
         public string ShortSha => this.Sha.Substring(0, 7);
 
-        public bool SubtreeRoot { get; } = false;
+        public bool SubtreeRoot { get; }
+
 
         public List<Commit> Parents { get; } = new List<Commit>();
     }

--- a/MinVer.Lib/Commit.cs
+++ b/MinVer.Lib/Commit.cs
@@ -4,11 +4,13 @@ namespace MinVer.Lib
 
     internal class Commit
     {
-        public Commit(string sha) => this.Sha = sha;
+        public Commit(string sha, bool subtreeRoot = false) => (this.Sha, this.SubtreeRoot) = (sha, subtreeRoot);
 
         public string Sha { get; }
 
         public string ShortSha => this.Sha.Substring(0, 7);
+
+        public bool SubtreeRoot { get; } = false;
 
         public List<Commit> Parents { get; } = new List<Commit>();
     }

--- a/MinVer.Lib/Repository.cs
+++ b/MinVer.Lib/Repository.cs
@@ -123,7 +123,7 @@ namespace MinVer.Lib
 
                         if (commitsToCheck.Count == 0 || commitsToCheck.Peek().Item2 <= height)
                         {
-                            var candidate = new Candidate { Commit = commit, Height = height, Tag = null, Version = new Version(defaultPreReleasePhase), };
+                            var candidate = new Candidate { Commit = commit, Height = height, Tag = null, Version = new Version(defaultPreReleasePhase, commit.SubtreeRoot), };
 
                             if (log.IsTraceEnabled)
                             {
@@ -217,7 +217,7 @@ namespace MinVer.Lib
             public override string ToString() => this.ToString(0, 0, 0);
 
             public string ToString(int tagWidth, int versionWidth, int heightWidth) =>
-                $"{{ {nameof(this.Commit)}: {this.Commit.ShortSha}, {nameof(this.Tag)}: {$"{(this.Tag == null ? "null" : $"'{this.Tag}'")},".PadRight(tagWidth + 3)} {nameof(this.Version)}: {$"{this.Version?.ToString() ?? "null"},".PadRight(versionWidth + 1)} {nameof(this.Height)}: {this.Height.ToString(CultureInfo.CurrentCulture).PadLeft(heightWidth)} }}";
+                $"{{ {nameof(this.Commit)}: {this.Commit.ShortSha}, {nameof(this.Tag)}: {$"{(this.Tag == null ? "null" : $"'{this.Tag}'")},".PadRight(tagWidth + 3)} {nameof(this.Version)}: {$"{this.Version?.ToString() ?? "null"},".PadRight(versionWidth + 1)} {nameof(this.Height)}: {this.Height.ToString(CultureInfo.CurrentCulture).PadLeft(heightWidth)}{(this.Commit.SubtreeRoot ? ", SubtreeRoot":"")} }}";
         }
     }
 }

--- a/MinVer.Lib/Version.cs
+++ b/MinVer.Lib/Version.cs
@@ -15,8 +15,9 @@ namespace MinVer.Lib
         private readonly List<string> preReleaseIdentifiers;
         private readonly int height;
         private readonly string buildMetadata;
+        private readonly bool subtreeRoot = false;
 
-        public Version(string defaultPreReleasePhase) : this(0, 0, 0, new List<string> { defaultPreReleasePhase, "0" }, 0, null) { }
+        public Version(string defaultPreReleasePhase, bool subtreeRoot = false) : this(0, 0, 0, new List<string> { defaultPreReleasePhase, "0" }, 0, null) { this.subtreeRoot = subtreeRoot;  }
 
         private Version(int major, int minor, int patch, IEnumerable<string> preReleaseIdentifiers, int height, string buildMetadata)
         {
@@ -54,6 +55,12 @@ namespace MinVer.Lib
             if (patch != 0)
             {
                 return patch;
+            }
+
+            var subtreeRoot = this.subtreeRoot.CompareTo(other.subtreeRoot);
+            if (subtreeRoot != 0)
+            {
+                return -subtreeRoot;
             }
 
             if (this.preReleaseIdentifiers.Count > 0 && other.preReleaseIdentifiers.Count == 0)


### PR DESCRIPTION
Using the fact that 'git subtree add' adds a comment to the commit containing 'git-subtree-dir' we try to identify such commits and thus avoid that they are erroneously identified as root commit.
#363 