### PR TITLE
align error message for invalid verbosity value

### DIFF
--- a/MinVer/Logger.cs
+++ b/MinVer/Logger.cs
@@ -55,7 +55,7 @@ namespace MinVer
             Error(1003, $"Invalid minimum MAJOR.MINOR '{minMajorMinor}'. Valid values are {MajorMinor.ValidValues}");
 
         public static void ErrorInvalidVerbosity(string verbosity) =>
-            Error(1004, $"Invalid verbosity '{verbosity}'. The value must be {VerbosityMap.ValidValue}.");
+            Error(1004, $"Invalid verbosity '{verbosity}'. Valid values are {VerbosityMap.ValidValues}.");
 
 #if MINVER
         public static void ErrorInvalidVersionOverride(string versionOverride) =>

--- a/MinVer/VerbosityMap.cs
+++ b/MinVer/VerbosityMap.cs
@@ -23,7 +23,7 @@ namespace MinVer
         }
 
         // spell-checker:disable
-        public static string ValidValue => "q[uiet], m[inimal] (default), n[ormal], d[etailed], or diag[nostic] (case insensitive)";
+        public static string ValidValues => "q[uiet], m[inimal] (default), n[ormal], d[etailed], or diag[nostic] (case insensitive)";
 
         // spell-checker:enable
         public static bool TryMap(string value, out Verbosity verbosity) => map.TryGetValue(value, out verbosity);

--- a/minver-cli/Logger.cs
+++ b/minver-cli/Logger.cs
@@ -55,7 +55,7 @@ namespace MinVer
             Error($"Invalid minimum MAJOR.MINOR '{minMajorMinor}'. Valid values are {MajorMinor.ValidValues}");
 
         public static void ErrorInvalidVerbosity(string verbosity) =>
-            Error($"Invalid verbosity '{verbosity}'. The value must be {VerbosityMap.ValidValue}.");
+            Error($"Invalid verbosity '{verbosity}'. Valid values are {VerbosityMap.ValidValues}.");
 
         private static void Error(string message) => Message($"error : {message}");
 

--- a/minver-cli/Program.cs
+++ b/minver-cli/Program.cs
@@ -23,7 +23,7 @@ namespace MinVer
                 var minMajorMinorOption = app.Option("-m|--minimum-major-minor <MINIMUM_MAJOR_MINOR>", MajorMinor.ValidValues, CommandOptionType.SingleValue);
                 var workDirOption = app.Option("-r|--repo <REPO>", "Working directory.", CommandOptionType.SingleValue);
                 var tagPrefixOption = app.Option("-t|--tag-prefix <TAG_PREFIX>", "", CommandOptionType.SingleValue);
-                var verbosityOption = app.Option("-v|--verbosity <VERBOSITY>", VerbosityMap.ValidValue, CommandOptionType.SingleValue);
+                var verbosityOption = app.Option("-v|--verbosity <VERBOSITY>", VerbosityMap.ValidValues, CommandOptionType.SingleValue);
 #if MINVER
                 var versionOverrideOption = app.Option("-o|--version-override <VERSION>", "", CommandOptionType.SingleValue);
 #endif

--- a/minver-cli/VerbosityMap.cs
+++ b/minver-cli/VerbosityMap.cs
@@ -23,7 +23,7 @@ namespace MinVer
         }
 
         // spell-checker:disable
-        public static string ValidValue => "e[rror], w[arn], i[nfo] (default), d[ebug], or t[race] (case insensitive)";
+        public static string ValidValues => "e[rror], w[arn], i[nfo] (default), d[ebug], or t[race] (case insensitive)";
 
         // spell-checker:enable
         public static bool TryMap(string value, out Verbosity verbosity) => map.TryGetValue(value, out verbosity);


### PR DESCRIPTION
## Before

```bash
> minver --auto-increment foo
MinVer: error : Invalid auto increment 'foo'. Valid values are major, minor, or patch (default)
> minver --verbosity foo
MinVer: error : Invalid verbosity 'foo'. The value must be e[rror], w[arn], i[nfo] (default), d[ebug], or t[race] (case insensitive).
```

## After

```bash
> minver --auto-increment foo
MinVer: error : Invalid auto increment 'foo'. Valid values are major, minor, or patch (default)
> minver --verbosity foo
MinVer: error : Invalid verbosity 'foo'. Valid values are e[rror], w[arn], i[nfo] (default), d[ebug], or t[race] (case insensitive).
```


And similar for the regular MinVer package.