### PR TITLE
Support versions with multiple "-" or "+" signs

### DIFF
--- a/MinVer/build/MinVer.targets
+++ b/MinVer/build/MinVer.targets
@@ -48,9 +48,9 @@
       <MinVerMinor>$(MinVerVersion.Split(`.`)[1])</MinVerMinor>
       <MinVerPatch>$(MinVerVersion.Split(`.`)[2].Split(`-`)[0].Split(`+`)[0])</MinVerPatch>
       <MinVerPreRelease></MinVerPreRelease>
-      <MinVerPreRelease Condition="$(MinVerVersion.Split(`+`)[0].Contains(`-`))">$(MinVerVersion.Split(`+`)[0].Split(`-`)[1])</MinVerPreRelease>
+      <MinVerPreRelease Condition="$(MinVerVersion.Split(`+`)[0].Contains(`-`))">$(MinVerVersion.Split(`+`)[0].Split(`-`, 2)[1])</MinVerPreRelease>
       <MinVerBuildMetadata></MinVerBuildMetadata>
-      <MinVerBuildMetadata Condition="$(MinVerVersion.Contains(`+`))">$(MinVerVersion.Split(`+`)[1])</MinVerBuildMetadata>
+      <MinVerBuildMetadata Condition="$(MinVerVersion.Contains(`+`))">$(MinVerVersion.Split(`+`, 2)[1])</MinVerBuildMetadata>
       <AssemblyVersion>$(MinVerMajor).0.0.0</AssemblyVersion>
       <FileVersion>$(MinVerMajor).$(MinVerMinor).$(MinVerPatch).0</FileVersion>
       <PackageVersion>$(MinVerVersion)</PackageVersion>


### PR DESCRIPTION
Currently if the version looks like `1.0.0-alpha-beta` it will be treated like it has a `PreRelease` part equal to `alpha`.

The `PreRelease` part needs to be `alpha-beta` if you look at [semver spec](https://semver.org/#spec-item-9), that allows extra dash characters in the `PreRelease` part.

The `BuildMetadata` part has a similar issue, with the plus sign., i. e. for `1.0.0+123+321` it will be computed to `123` and not `123+321`. Multiple pluses in version is not valid semver, and will probably cause an error when used with nuget. Despite that, it still feels like a similar issue should be fixed there.

In sum, for version `1.0.0-alpha-beta+123+321` this commit will set `MinVerPreRelease` to `alpha-beta` instead of current `alpha` and will set `MinVerBuildMetadata` to `123+321` instead of current `123`.