### PR TITLE
Handle incrementing the height of pre-release versions more sensibly

### DIFF
--- a/MinVer.Lib/Version.cs
+++ b/MinVer.Lib/Version.cs
@@ -122,6 +122,11 @@ namespace MinVer.Lib
                 }
             }
 
+            if (this.preReleaseIdentifiers.Count == 3 && height > 0 && int.TryParse(this.preReleaseIdentifiers.Last(), out var prereleaseHeight))
+            {
+                return new Version(this.major, this.minor, this.patch, this.preReleaseIdentifiers.Take(2), prereleaseHeight + height, this.buildMetadata);
+            }
+
             return new Version(this.major, this.minor, this.patch, this.preReleaseIdentifiers, height, height == 0 ? this.buildMetadata : null);
         }
 

--- a/MinVerTests.Lib/AutoIncrement.cs
+++ b/MinVerTests.Lib/AutoIncrement.cs
@@ -31,5 +31,30 @@ namespace MinVerTests.Lib
             $"Then the version is '{expectedVersion}'"
                 .x(() => Assert.Equal(expectedVersion, actualVersion.ToString()));
         }
+
+        [Scenario]
+        [Example("1.0.0-alpha.0.1", VersionPart.Minor, "1.0.0-alpha.0.3")]
+        [Example("1.0.0-alpha.0.1", VersionPart.Patch, "1.0.0-alpha.0.3")]
+        [Example("1.0.0-alpha.0.1", VersionPart.Major, "1.0.0-alpha.0.3")]
+        public static void PrereleaseVersionIncrement(string tag, VersionPart autoIncrement, string expectedVersion, string path, Version actualVersion)
+        {
+            $"Given a git repository with a commit in '{path = GetScenarioDirectory($"rtm-auto-increment-{tag}")}'"
+                .x(() => EnsureEmptyRepositoryAndCommit(path));
+
+            $"And the commit is tagged '{tag}'"
+                .x(() => Tag(path, tag));
+
+            "And another commit"
+                .x(() => Commit(path));
+
+            "And another commit"
+                .x(() => Commit(path));
+
+            $"When the version is determined using auto-increment '{autoIncrement}'"
+                .x(() => actualVersion = Versioner.GetVersion(path, default, default, default, autoIncrement, default, new TestLogger()));
+
+            $"Then the version is '{expectedVersion}'"
+                .x(() => Assert.Equal(expectedVersion, actualVersion.ToString()));
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ _NOTE: The MinVer package reference should normally include `PrivateAssets="All"
   - The commit history is searched for the latest commit with a version tag.
     - If a commit with a version tag is found:
       - If the version is a [pre-release](https://semver.org/spec/v2.0.0.html#spec-item-9):
-        - The version is used as-is, with [height](#height) added.
+        - The current pre-release height is incremented by the new [height](#height).
+        - For example, if the latest version tag is `1.0.0-alpha.0.1` and the new height is 2, the current version is `1.0.0-alpha.0.3`.
       - If the version is RTM (not pre-release):
         - The patch number is incremented, but this [can be customised](#can-i-auto-increment-the-minor-or-major-version-after-an-rtm-tag-instead-of-the-patch-version).
         - Default pre-release identifiers are added. The default pre-release phase is "alpha", but this [can be customised](#can-i-change-the-default-pre-release-phase-from-alpha-to-something-else).


### PR DESCRIPTION
Addresses the problem described on https://github.com/adamralph/minver/discussions/488