### PR TITLE
tweak changes to more idiomatic CliWrap usage

### DIFF
--- a/MinVerTests.Infra/CliWrapExtensions.cs
+++ b/MinVerTests.Infra/CliWrapExtensions.cs
@@ -11,7 +11,7 @@ using CliWrap.Exceptions;
 
 namespace MinVerTests.Infra
 {
-    internal static class CommandExtensions
+    internal static class CliWrapExtensions
     {
         private static int index;
 
@@ -21,7 +21,7 @@ namespace MinVerTests.Infra
 
             var result = await command.WithValidation(CommandResultValidation.None).ExecuteBufferedAsync();
 
-            var index = Interlocked.Increment(ref CommandExtensions.index);
+            var index = Interlocked.Increment(ref CliWrapExtensions.index);
 
             var log =
 $@"
@@ -77,7 +77,7 @@ $@"
             return env;
         }
 
-        public static ArgumentsBuilder AddIf(this ArgumentsBuilder args, string value, bool condition)
+        public static ArgumentsBuilder AddIf(this ArgumentsBuilder args, bool condition, string value)
         {
             if (condition)
             {

--- a/MinVerTests.Infra/Git.cs
+++ b/MinVerTests.Infra/Git.cs
@@ -35,7 +35,7 @@ namespace MinVerTests.Infra
                 .WithArguments("log --graph --pretty=format:'%d'")
                 .WithWorkingDirectory(path)
                 .ExecuteBufferedAsync()
-                .Select(r => r.StandardOutput);
+                .Select(result => result.StandardOutput);
 
         public static Task Tag(string path, string tag) =>
             Cli.Wrap("git").WithArguments($"tag {tag}").WithWorkingDirectory(path).ExecuteAsync();

--- a/MinVerTests.Infra/Sdk.cs
+++ b/MinVerTests.Infra/Sdk.cs
@@ -121,7 +121,7 @@ $@"{{
                 .WithArguments(args => args
                     .Add("build")
                     .Add("--no-restore")
-                    .AddIf("--nologo", !(Version?.StartsWith("2.", StringComparison.Ordinal) ?? false))
+                    .AddIf(!(Version?.StartsWith("2.", StringComparison.Ordinal) ?? false), "--nologo")
                 )
                 .WithEnvironmentVariables(env => env
                     .SetFrom(environmentVariables)


### PR DESCRIPTION
relates to https://github.com/adamralph/minver/pull/546

- Given that `CommandExtensions` now contains more than just extensions to `Command`, I thought it more appropriate to name it `CliWrapExtensions`.
- `AddIf(condition, value)` felt more natural than `AddIf(value, condition)`