### PR TITLE
An empty working directory argument or option (deprecated) is ignored in minver-cli

### DIFF
--- a/minver-cli/Program.cs
+++ b/minver-cli/Program.cs
@@ -31,7 +31,7 @@ namespace MinVer
 
             app.OnExecute(() =>
             {
-                var workDir = !string.IsNullOrEmpty(workDirArg.Value) ? workDirArg.Value : ".";
+                var workDir = workDirArg.Value ?? ".";
 
                 if (!Directory.Exists(workDir))
                 {


### PR DESCRIPTION
## Version(s)

1.0.0 - 2.5.0

## To reproduce

Steps to reproduce the behaviour:

1. Run `minver-cli ""` in a Windows command prompt (not PowerShell).

## Expected behaviour

The command fails with

> MinVer: error : Working directory '' does not exist.

## Actual behaviour

The command succeeds.

## Workarounds

Avoid passing an empty working directory argument.

## Additional context

Fixing this is regarded as a breaking change, since current consumers may rely on the incorrect behaviour.

The behaviour is not reproducible in PowerShell because PowerShell appears to ignore `""` and does not propagate it as an argument.
