### PR TITLE
update .NET SDK from 6.0.100-rc.1.21458.32 to 6.0.100-rc.1.21463.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
               build: ./build.sh
             tests:
               framework: net6.0
-              sdk: "6.0.100-rc.1.21458.32"
+              sdk: "6.0.100-rc.1.21463.6"
           - job:
               os: ubuntu-18.04
               build: ./build.sh
@@ -54,7 +54,7 @@ jobs:
               build: ./build.sh
             tests:
               framework: net6.0
-              sdk: "6.0.100-rc.1.21458.32"
+              sdk: "6.0.100-rc.1.21463.6"
           - job:
               os: windows-2016
               build: ./build.cmd
@@ -72,7 +72,7 @@ jobs:
               build: ./build.cmd
             tests:
               framework: net6.0
-              sdk: "6.0.100-rc.1.21458.32"
+              sdk: "6.0.100-rc.1.21463.6"
           - job:
               os: windows-2022
               build: ./build.cmd


### PR DESCRIPTION
You read it right—there are _multiple versions_ of RC 1, even though there is "only one" RC 1.

![image](https://user-images.githubusercontent.com/677704/135729386-b0baff17-6348-45f3-bc38-ff83732cd6ca.png)
