### PR TITLE
feature: Supports GitHub Action set-output

### DIFF
--- a/MinVer.Lib/Version.cs
+++ b/MinVer.Lib/Version.cs
@@ -7,27 +7,28 @@ namespace MinVer.Lib
 {
     public class Version : IComparable<Version>
     {
-        private readonly int major;
-        private readonly int minor;
-        private readonly int patch;
         private readonly List<string> preReleaseIdentifiers;
-        private readonly int height;
-        private readonly string buildMetadata;
+        public int Major { get; }
+        public int Minor { get; }
+        public int Patch { get; }
+        public int Height { get; }
+        public string BuildMetaData { get; }
+        public string PreReleaseIdentifier => this.preReleaseIdentifiers.Count == 0 ? "" : $"{string.Join(".", this.preReleaseIdentifiers)}";
 
         public Version(string defaultPreReleasePhase) : this(0, 0, 0, new List<string> { defaultPreReleasePhase, "0" }, 0, null) { }
 
         private Version(int major, int minor, int patch, IEnumerable<string> preReleaseIdentifiers, int height, string buildMetadata)
         {
-            this.major = major;
-            this.minor = minor;
-            this.patch = patch;
+            this.Major = major;
+            this.Minor = minor;
+            this.Patch = patch;
             this.preReleaseIdentifiers = preReleaseIdentifiers?.ToList() ?? new List<string>();
-            this.height = height;
-            this.buildMetadata = buildMetadata;
+            this.Height = height;
+            this.BuildMetaData = buildMetadata;
         }
 
         public override string ToString() =>
-            $"{this.major}.{this.minor}.{this.patch}{(this.preReleaseIdentifiers.Count == 0 ? "" : $"-{string.Join(".", this.preReleaseIdentifiers)}")}{(this.height == 0 ? "" : $".{this.height}")}{(string.IsNullOrEmpty(this.buildMetadata) ? "" : $"+{this.buildMetadata}")}";
+            $"{this.Major}.{this.Minor}.{this.Patch}{(this.preReleaseIdentifiers.Count == 0 ? "" : $"-{string.Join(".", this.preReleaseIdentifiers)}")}{(this.Height == 0 ? "" : $".{this.Height}")}{(string.IsNullOrEmpty(this.BuildMetaData) ? "" : $"+{this.BuildMetaData}")}";
 
         public int CompareTo(Version other)
         {
@@ -36,19 +37,19 @@ namespace MinVer.Lib
                 return 1;
             }
 
-            var major = this.major.CompareTo(other.major);
+            var major = this.Major.CompareTo(other.Major);
             if (major != 0)
             {
                 return major;
             }
 
-            var minor = this.minor.CompareTo(other.minor);
+            var minor = this.Minor.CompareTo(other.Minor);
             if (minor != 0)
             {
                 return minor;
             }
 
-            var patch = this.patch.CompareTo(other.patch);
+            var patch = this.Patch.CompareTo(other.Patch);
             if (patch != 0)
             {
                 return patch;
@@ -95,29 +96,29 @@ namespace MinVer.Lib
                 }
             }
 
-            return this.height.CompareTo(other.height);
+            return this.Height.CompareTo(other.Height);
         }
 
         public Version Satisfying(MajorMinor minMajorMinor, string defaultPreReleasePhase) =>
-            minMajorMinor == null || minMajorMinor.Major < this.major || (minMajorMinor.Major == this.major && minMajorMinor.Minor <= this.minor)
+            minMajorMinor == null || minMajorMinor.Major < this.Major || (minMajorMinor.Major == this.Major && minMajorMinor.Minor <= this.Minor)
                 ? this
-                : new Version(minMajorMinor.Major, minMajorMinor.Minor, 0, new[] { defaultPreReleasePhase, "0" }, this.height, this.buildMetadata);
+                : new Version(minMajorMinor.Major, minMajorMinor.Minor, 0, new[] { defaultPreReleasePhase, "0" }, this.Height, this.BuildMetaData);
 
         public Version WithHeight(int height, VersionPart autoIncrement, string defaultPreReleasePhase) =>
             this.preReleaseIdentifiers.Count == 0 && height > 0
                 ? autoIncrement switch
                 {
-                    VersionPart.Major => new Version(this.major + 1, 0, 0, new[] { defaultPreReleasePhase, "0" }, height, null),
-                    VersionPart.Minor => new Version(this.major, this.minor + 1, 0, new[] { defaultPreReleasePhase, "0" }, height, null),
-                    VersionPart.Patch => new Version(this.major, this.minor, this.patch + 1, new[] { defaultPreReleasePhase, "0" }, height, null),
+                    VersionPart.Major => new Version(this.Major + 1, 0, 0, new[] { defaultPreReleasePhase, "0" }, height, null),
+                    VersionPart.Minor => new Version(this.Major, this.Minor + 1, 0, new[] { defaultPreReleasePhase, "0" }, height, null),
+                    VersionPart.Patch => new Version(this.Major, this.Minor, this.Patch + 1, new[] { defaultPreReleasePhase, "0" }, height, null),
                     _ => throw new ArgumentOutOfRangeException(nameof(autoIncrement)),
                 }
-                : new Version(this.major, this.minor, this.patch, this.preReleaseIdentifiers, height, height == 0 ? this.buildMetadata : null);
+                : new Version(this.Major, this.Minor, this.Patch, this.preReleaseIdentifiers, height, height == 0 ? this.BuildMetaData : null);
 
         public Version AddBuildMetadata(string buildMetadata)
         {
-            var separator = !string.IsNullOrEmpty(this.buildMetadata) && !string.IsNullOrEmpty(buildMetadata) ? "." : "";
-            return new Version(this.major, this.minor, this.patch, this.preReleaseIdentifiers, this.height, $"{this.buildMetadata}{separator}{buildMetadata}");
+            var separator = !string.IsNullOrEmpty(this.BuildMetaData) && !string.IsNullOrEmpty(buildMetadata) ? "." : "";
+            return new Version(this.Major, this.Minor, this.Patch, this.preReleaseIdentifiers, this.Height, $"{this.BuildMetaData}{separator}{buildMetadata}");
         }
 
         public static bool TryParse(string text, out Version version) => (version = ParseOrDefault(text, null)) != null;
@@ -154,12 +155,12 @@ namespace MinVer.Lib
             {
                 var code = 17;
 
-                code = (code * 23) + this.major.GetHashCode();
-                code = (code * 23) + this.minor.GetHashCode();
-                code = (code * 23) + this.patch.GetHashCode();
+                code = (code * 23) + this.Major.GetHashCode();
+                code = (code * 23) + this.Minor.GetHashCode();
+                code = (code * 23) + this.Patch.GetHashCode();
                 code = (code * 23) + this.preReleaseIdentifiers.GetHashCode();
-                code = (code * 23) + this.height.GetHashCode();
-                code = (code * 23) + this.buildMetadata.GetHashCode(StringComparison.Ordinal);
+                code = (code * 23) + this.Height.GetHashCode();
+                code = (code * 23) + this.BuildMetaData.GetHashCode(StringComparison.Ordinal);
 
                 return code;
             }

--- a/minver-cli/Options.cs
+++ b/minver-cli/Options.cs
@@ -91,6 +91,7 @@ namespace MinVer
             string minMajorMinorOption,
             string tagPrefixOption,
             string verbosityOption,
+            bool writeGitHubActionOutput,
 #if MINVER
             string versionOverrideOption,
 #endif
@@ -136,6 +137,8 @@ namespace MinVer
                 options.Verbosity = verbosity;
             }
 
+            options.ShowGitHubActionOutput = writeGitHubActionOutput;
+
 #if MINVER
             if (!string.IsNullOrEmpty(versionOverrideOption))
             {
@@ -162,6 +165,7 @@ namespace MinVer
                 TagPrefix = this.TagPrefix ?? other.TagPrefix,
                 Verbosity = this.Verbosity == default ? other.Verbosity : this.Verbosity,
                 VersionOverride = this.VersionOverride ?? other.VersionOverride,
+                ShowGitHubActionOutput = this.ShowGitHubActionOutput ? this.ShowGitHubActionOutput : other.ShowGitHubActionOutput,
             };
 
         public VersionPart AutoIncrement { get; private set; }
@@ -177,5 +181,7 @@ namespace MinVer
         public Verbosity Verbosity { get; private set; }
 
         public Lib.Version VersionOverride { get; private set; }
+
+        public bool ShowGitHubActionOutput { get; private set; }
     }
 }

--- a/minver-cli/Program.cs
+++ b/minver-cli/Program.cs
@@ -25,6 +25,7 @@ namespace MinVer
             var minMajorMinorOption = app.Option("-m|--minimum-major-minor <MINIMUM_MAJOR_MINOR>", MajorMinor.ValidValues, CommandOptionType.SingleValue);
             var tagPrefixOption = app.Option("-t|--tag-prefix <TAG_PREFIX>", "", CommandOptionType.SingleValue);
             var verbosityOption = app.Option("-v|--verbosity <VERBOSITY>", VerbosityMap.ValidValues, CommandOptionType.SingleValue);
+            var showGitHubActionOutput = app.Option("-s|--show-github-action-output", "Show GitHub Action ::set-output variable assignments", CommandOptionType.NoValue);
 #if MINVER
             var versionOverrideOption = app.Option("-o|--version-override <VERSION>", "", CommandOptionType.SingleValue);
 #endif
@@ -46,6 +47,7 @@ namespace MinVer
                     minMajorMinorOption.Value(),
                     tagPrefixOption.Value(),
                     verbosityOption.Value(),
+                    showGitHubActionOutput.Values.Count > 0,
 #if MINVER
                     versionOverrideOption.Value(),
 #endif
@@ -80,6 +82,17 @@ namespace MinVer
                 }
 
                 var version = Versioner.GetVersion(workDir, options.TagPrefix, options.MinMajorMinor, options.BuildMeta, options.AutoIncrement, options.DefaultPreReleasePhase, log);
+
+                if (options.ShowGitHubActionOutput)
+                {
+                    Console.Out.WriteLine($"::set-output name=MinVerMajor::{version.Major}");
+                    Console.Out.WriteLine($"::set-output name=MinVerMinor::{version.Minor}");
+                    Console.Out.WriteLine($"::set-output name=MinVerPatch::{version.Patch}");
+                    Console.Out.WriteLine($"::set-output name=MinVerPreReleaseIdentifier::{version.PreReleaseIdentifier}");
+                    Console.Out.WriteLine($"::set-output name=MinVerBuildMetaData::{version.BuildMetaData}");
+                    Console.Out.WriteLine($"::set-output name=MinVerPreHeight::{version.Height}");
+                    Console.Out.WriteLine($"::set-output name=MinVerVersion::{version}");
+                }
 
                 Console.Out.WriteLine(version);
 


### PR DESCRIPTION
Hi! 

Thanks for the effort you and others have put into this prosject making versioning with git real simple! 

I've taken the liberty to create this PR to simplify using MinVer computed values in a GitHub Action workflow. This PR solves this by adding a switch `-s|--show-github-action-output` to the `minver-cli.exe` making it output the following during the workflow. 

`minver-cli.exe -s`
```
::set-output name=MinVerMajor::0
::set-output name=MinVerMinor::0
::set-output name=MinVerPatch::0
::set-output name=MinVerPreReleaseIdentifier::alpha.0
::set-output name=MinVerBuildMetaData::
::set-output name=MinVerPreHeight::0
::set-output name=MinVerVersion::0.0.0-alpha.0
```

This allows other steps in the workflow to access those variables, i.e:
```
MinVerVersion = ${{ steps.minver.outputs.MinVerVersion }}
MinVerMajor = ${{ steps.minver.outputs.MinVerMajor }}
MinVerMinor = ${{ steps.minver.outputs.MinVerMinor }}
MinVerPatch = ${{ steps.minver.outputs.MinVerPatch }}
MinVerPreReleaseIdentifier = ${{ steps.minver.outputs.MinVerPreReleaseIdentifier }}
MinVerBuildMetaData = ${{ steps.minver.outputs.MinVerBuildMetaData }}
MinVerPreHeight = ${{ steps.minver.outputs.MinVerPreHeight }}
MinVerVersion = ${{ steps.minver.outputs.MinVerVersion }}
```
Ref: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idoutputs

My usecase for doing this is to be able to tag a docker image at build time with the values from MinVer while not using the complete semver string returned. 

If this has already been resolved or there are better solutions to this problem please close this PR!