### PR TITLE
don't run MinVer before Clean when packages are not generated on build

### DIFF
--- a/MinVer/build/MinVer.targets
+++ b/MinVer/build/MinVer.targets
@@ -12,7 +12,9 @@
     <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
 
-  <Target Name="MinVer" BeforeTargets="Clean;BeforeCompile;GetAssemblyVersion;CoreCompile" Condition="'$(DesignTimeBuild)' != 'true' AND '$(MinVerSkip)' != 'true'">
+  <Target Name="_MinVerClean" BeforeTargets="Clean" DependsOnTargets="MinVer" Condition="'$(GeneratePackageOnBuild)' == 'true'" />
+
+  <Target Name="MinVer" BeforeTargets="BeforeCompile;GetAssemblyVersion;CoreCompile" Condition="'$(DesignTimeBuild)' != 'true' AND '$(MinVerSkip)' != 'true'">
     <Error Condition="'$(UsingMicrosoftNETSdk)' != 'true'" Code="MINVER0001" Text="MinVer only works in SDK-style projects." />
     <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MSBuildProjectDirectory=$(MSBuildProjectDirectory)" />
     <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MinVerAutoIncrement=$(MinVerAutoIncrement)" />

--- a/MinVerTests.Packages/Cleaning.cs
+++ b/MinVerTests.Packages/Cleaning.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -32,6 +33,27 @@ namespace MinVerTests.Packages
 
             // assert
             Assert.Empty(packages.GetResultsInFullPath(path));
+        }
+
+        [Fact]
+        public static async Task MinVerDoesNotRunWhenPackagesAreNotGeneratedOnBuild()
+        {
+            // arrange
+            var path = MethodBase.GetCurrentMethod().GetTestDirectory();
+            await Sdk.CreateProject(path);
+
+            // act
+            var result = await Sdk.DotNet(
+                "clean",
+                path,
+                new Dictionary<string, string>
+                {
+                    { "GeneratePackageOnBuild", "false" },
+                    { "MinVerVerbosity", "diagnostic" },
+                });
+
+            // assert
+            Assert.DoesNotContain("minver:", result.StandardOutput, StringComparison.OrdinalIgnoreCase);
         }
     }
 }


### PR DESCRIPTION
backporting https://github.com/adamralph/minver/pull/704 to `release-3.0`

closes #683 