### PR TITLE
Better debug log message when no commit found with a version tag

### DIFF
--- a/MinVer.Lib/Versioner.cs
+++ b/MinVer.Lib/Versioner.cs
@@ -68,7 +68,7 @@ public static class Versioner
 
         var selectedCandidate = orderedCandidates.Last();
 
-        _ = string.IsNullOrEmpty(selectedCandidate.Tag) && log.IsInfoEnabled && log.Info($"No commit found with a valid SemVer 2.0 version{(string.IsNullOrEmpty(tagPrefix) ? "" : $" prefixed with '{tagPrefix}'")}. Using default version {selectedCandidate.Version}.");
+        _ = string.IsNullOrEmpty(selectedCandidate.Tag) && log.IsInfoEnabled && log.Info($"No commit found with a version tag{(string.IsNullOrEmpty(tagPrefix) ? "" : $" prefixed with '{tagPrefix}'")}. Using default version {selectedCandidate.Version}.");
         _ = log.IsInfoEnabled && log.Info($"Using{(log.IsDebugEnabled && orderedCandidates.Count > 1 ? "    " : " ")}{selectedCandidate.ToString(tagWidth, versionWidth, heightWidth)}.");
         _ = ignoreHeight && log.IsDebugEnabled && log.Debug("Ignoring height.");
 


### PR DESCRIPTION
For context, MinVer is more relaxed than SemVer 2.0 in what it accepts as a version. For example, MinVer allows pre-release identifiers with leading zeros, so it would treat something like `1.0.0-beta.0001` as a valid version.

## Before

> No commit found with a valid SemVer 2.0 version.

This doesn't tell the whole story. While it's true that no commit with a valid SemVer 2.0 version was found, you could, for example tag a commit `1.0.0-beta.0001`, which isn't valid SemVer 2.0, and the message would no longer appear, implying that a commit _was_ found with a valid SemVer 2.0 version, which can't be true.

## After

> No commit found with a version tag.

---

The README still talks about SemVer 2.0, but it seems OK to at least _guide_ people towards using SemVer 2.0, even though MinVer allows a superset of the version strings SemVer 2.0 does.