### PR TITLE
drop support for .NET Core

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -29,7 +29,6 @@
     "MINVERVERSIONOVERRIDE",
     "MyGet",
     "Nerdbank",
-    "netcoreapp",
     "netstandard",
     "NOLOGO",
     "notnull",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,12 +43,6 @@ jobs:
           - job:
               os: ubuntu-22.04
             tests:
-              framework: netcoreapp3.1
-              sdk: "3.1.425"
-              sdk-major-minor: "3.1"
-          - job:
-              os: ubuntu-22.04
-            tests:
               framework: net6.0
               sdk: "6.0.403"
               sdk-major-minor: "6.0"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,7 +2,7 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": ".NET Core Launch (console)",
+      "name": ".NET Launch (console)",
       "type": "coreclr",
       "request": "launch",
       "program": "${workspaceFolder}/targets/bin/Debug/net7.0/Targets.dll",
@@ -12,7 +12,7 @@
       "console": "internalConsole"
     },
     {
-      "name": ".NET Core Attach",
+      "name": ".NET Attach",
       "type": "coreclr",
       "request": "attach",
       "processId": "${command:pickProcess}"

--- a/MinVer.Lib/MinVer.Lib.csproj
+++ b/MinVer.Lib/MinVer.Lib.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <LangVersion>default</LangVersion>
   </PropertyGroup>
 

--- a/MinVer/MinVer.csproj
+++ b/MinVer/MinVer.csproj
@@ -18,7 +18,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RollForward>major</RollForward>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <LangVersion>default</LangVersion>
   </PropertyGroup>
 

--- a/MinVer/build/MinVer.targets
+++ b/MinVer/build/MinVer.targets
@@ -9,8 +9,7 @@
   <PropertyGroup>
     <MinVerDetailed>low</MinVerDetailed>
     <MinVerDetailed Condition="'$(MinVerVerbosity)' == 'detailed' Or '$(MinVerVerbosity)' == 'd' Or '$(MinVerVerbosity)' == 'diagnostic' Or '$(MinVerVerbosity)' == 'diag'">high</MinVerDetailed>
-    <MinVerTargetFramework>netcoreapp3.1</MinVerTargetFramework>
-    <MinVerTargetFramework Condition="'$(MSBuildAssemblyVersion)' &gt;= '17.0'">net6.0</MinVerTargetFramework>
+    <MinVerTargetFramework>net6.0</MinVerTargetFramework>
     <MinVerTargetFramework Condition="'$(MSBuildAssemblyVersion)' &gt;= '17.4'">net7.0</MinVerTargetFramework>
     <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>

--- a/MinVerTests.Infra/MinVerCli.cs
+++ b/MinVerTests.Infra/MinVerCli.cs
@@ -15,9 +15,6 @@ namespace MinVerTests.Infra
         }
 
         public static string GetPath(string configuration) =>
-#if NETCOREAPP3_1
-            Solution.GetFullPath($"minver-cli/bin/{configuration}/netcoreapp3.1/minver-cli.dll");
-#endif
 #if NET6_0
             Solution.GetFullPath($"minver-cli/bin/{configuration}/net6.0/minver-cli.dll");
 #endif

--- a/MinVerTests.Infra/MinVerTests.Infra.csproj
+++ b/MinVerTests.Infra/MinVerTests.Infra.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MinVerTests.Lib/MinVerTests.Lib.csproj
+++ b/MinVerTests.Lib/MinVerTests.Lib.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RollForward>major</RollForward>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Also available as a [command-line tool](#can-i-use-minver-to-version-software-wh
 
 ## Prerequisites
 
-- [.NET Core SDK 3.1 or later](https://www.microsoft.com/net/download)
+- [.NET SDK 6.0 or later](https://www.microsoft.com/net/download)
 - [Git](https://git-scm.com/)
 
 ## Quick start

--- a/minver-cli/minver-cli.csproj
+++ b/minver-cli/minver-cli.csproj
@@ -14,7 +14,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RollForward>major</RollForward>
     <RootNamespace>MinVer</RootNamespace>
-    <TargetFrameworks>netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <ToolCommandName>minver</ToolCommandName>
     <LangVersion>default</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
To safely and simply take advantage of new features.

I'm doing this now because the last version, .NET Core 3.1, [goes out of support](https://dotnet.microsoft.com/en-us/download/dotnet) on December 13, 2022.