### PR TITLE
Add an MSBuild task to call MinVer

### DIFF
--- a/MinVer.MSBuild/MinVer.MSBuild.csproj
+++ b/MinVer.MSBuild/MinVer.MSBuild.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <LangVersion>12.0</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.1" PrivateAssets="All" ExcludeAssets="runtime" />
+  </ItemGroup>
+
+</Project>

--- a/MinVer.MSBuild/MinVerTask.cs
+++ b/MinVer.MSBuild/MinVerTask.cs
@@ -1,0 +1,101 @@
+#if NET
+using System.Globalization;
+#endif
+using System.Reflection;
+using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace MinVer.MSBuild;
+
+public class MinVerTask : ToolTask
+{
+    public string? GitWorkingDirectory { get; set; }
+
+    public string? AutoIncrement { get; set; }
+
+    public string? BuildMetadata { get; set; }
+
+    public string? DefaultPreReleaseIdentifiers { get; set; }
+
+    public string? DefaultPreReleasePhase { get; set; }
+
+    public string? IgnoreHeight { get; set; }
+
+    public string? MinimumMajorMinor { get; set; }
+
+    public string? TagPrefix { get; set; }
+
+    public string? Verbosity { get; set; }
+
+    public string? VersionOverride { get; set; }
+
+    public string TargetFramework { get; set; } = "net6.0";
+
+    [Output]
+    public string? Version { get; set; }
+
+    protected override string ToolName => "dotnet";
+
+    protected override string GenerateFullPathToTool() => "dotnet";
+
+    protected override MessageImportance StandardErrorLoggingImportance => this.Verbosity is not null and ("detailed" or "d" or "diagnostic" or "diag") ? MessageImportance.High : MessageImportance.Low;
+
+    protected override bool SkipTaskExecution() => base.SkipTaskExecution();
+
+    protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
+    {
+        if (singleLine is not null && !singleLine.StartsWith("MinVer", StringComparison.Ordinal))
+        {
+            this.Version = singleLine;
+        }
+
+        base.LogEventsFromTextOutput(singleLine, messageImportance);
+    }
+
+    protected override string GenerateCommandLineCommands()
+    {
+        var assemblyDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        var minVerPath = Path.GetFullPath(Path.Combine(assemblyDirectory!, "..", "..", "..", "minver", this.TargetFramework, "MinVer.dll"));
+
+        var builder = new StringBuilder();
+
+#if NET
+        _ = builder.Append(CultureInfo.InvariantCulture, $"\"{minVerPath}\" ");
+        _ = builder.Append(CultureInfo.InvariantCulture, $"\"{this.GitWorkingDirectory}\" ");
+        _ = builder.Append(CultureInfo.InvariantCulture, $"--auto-increment \"{this.AutoIncrement}\" ");
+        _ = builder.Append(CultureInfo.InvariantCulture, $"--build-metadata \"{this.BuildMetadata}\" ");
+        _ = builder.Append(CultureInfo.InvariantCulture, $"--default-pre-release-identifiers \"{this.DefaultPreReleaseIdentifiers}\" ");
+        _ = builder.Append(CultureInfo.InvariantCulture, $"--default-pre-release-phase \"{this.DefaultPreReleasePhase}\" ");
+
+        if (this.IgnoreHeight?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false)
+        {
+            _ = builder.Append("--ignore-height ");
+        }
+
+        _ = builder.Append(CultureInfo.InvariantCulture, $"--minimum-major-minor \"{this.MinimumMajorMinor}\" ");
+        _ = builder.Append(CultureInfo.InvariantCulture, $"--tag-prefix \"{this.TagPrefix}\" ");
+        _ = builder.Append(CultureInfo.InvariantCulture, $"--verbosity \"{this.Verbosity}\" ");
+        _ = builder.Append(CultureInfo.InvariantCulture, $"--version-override \"{this.VersionOverride}\" ");
+#else
+        _ = builder.Append($"\"{minVerPath}\" ");
+        _ = builder.Append($"\"{this.GitWorkingDirectory}\" ");
+        _ = builder.Append($"--auto-increment \"{this.AutoIncrement}\" ");
+        _ = builder.Append($"--build-metadata \"{this.BuildMetadata}\" ");
+        _ = builder.Append($"--default-pre-release-identifiers \"{this.DefaultPreReleaseIdentifiers}\" ");
+        _ = builder.Append($"--default-pre-release-phase \"{this.DefaultPreReleasePhase}\" ");
+
+        if (this.IgnoreHeight?.Equals("true", StringComparison.OrdinalIgnoreCase) ?? false)
+        {
+            _ = builder.Append("--ignore-height ");
+        }
+
+        _ = builder.Append($"--minimum-major-minor \"{this.MinimumMajorMinor}\" ");
+        _ = builder.Append($"--tag-prefix \"{this.TagPrefix}\" ");
+        _ = builder.Append($"--verbosity \"{this.Verbosity}\" ");
+        _ = builder.Append($"--version-override \"{this.VersionOverride}\" ");
+#endif
+
+        return builder.ToString();
+    }
+}

--- a/MinVer.sln
+++ b/MinVer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28922.388
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34723.18
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinVerTests.Lib", "MinVerTests.Lib\MinVerTests.Lib.csproj", "{57307B80-9750-4D4F-91DC-EE28EC89EDDD}"
 EndProject
@@ -16,6 +16,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinVerTests.Infra", "MinVerTests.Infra\MinVerTests.Infra.csproj", "{AA98F752-F8EF-447D-BC85-4F277CAF4B82}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinVerTests.Packages", "MinVerTests.Packages\MinVerTests.Packages.csproj", "{694ECAC7-FD05-4550-A4FB-8F497D29ECB0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinVer.MSBuild", "MinVer.MSBuild\MinVer.MSBuild.csproj", "{C0903586-F372-4B47-877F-0D8F2E2DC77B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,6 +53,10 @@ Global
 		{694ECAC7-FD05-4550-A4FB-8F497D29ECB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{694ECAC7-FD05-4550-A4FB-8F497D29ECB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{694ECAC7-FD05-4550-A4FB-8F497D29ECB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C0903586-F372-4B47-877F-0D8F2E2DC77B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C0903586-F372-4B47-877F-0D8F2E2DC77B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C0903586-F372-4B47-877F-0D8F2E2DC77B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C0903586-F372-4B47-877F-0D8F2E2DC77B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MinVer/MinVer.csproj
+++ b/MinVer/MinVer.csproj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\MinVer.MSBuild\MinVer.MSBuild.csproj" ReferenceOutputAssembly="false" Private="false" />
     <ProjectReference Include="..\MinVer.Lib\MinVer.Lib.csproj" PrivateAssets="All" />
   </ItemGroup>
 
@@ -42,6 +43,8 @@
     <None Remove="buildMultiTargeting\**\*" />
     <Content Include="build\**\*" PackagePath="build" />
     <Content Include="buildMultiTargeting\**\*" PackagePath="buildMultiTargeting" />
+    <None Include="..\MinVer.MSBuild\bin\$(Configuration)\net472\MinVer.MSBuild.dll" Pack="true" PackagePath="build\task\net472" Visible="false" />
+    <None Include="..\MinVer.MSBuild\bin\$(Configuration)\net6.0\MinVer.MSBuild.dll" Pack="true" PackagePath="build\task\net6.0" Visible="false" />
   </ItemGroup>
 
   <Target Name="AddMinVerOutput" BeforeTargets="_GetPackageFiles">

--- a/MinVer/build/MinVer.targets
+++ b/MinVer/build/MinVer.targets
@@ -4,7 +4,11 @@
     <MSBuildAllProjects Condition="'$(MSBuildAssemblyVersion)' == '' Or '$(MSBuildAssemblyVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);MinVer</GenerateNuspecDependsOn>
     <GetPackageVersionDependsOn>$(GetPackageVersionDependsOn);MinVer</GetPackageVersionDependsOn>
+    <MinVerTaskPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)task\net6.0\MinVer.MSBuild.dll</MinVerTaskPath>
+    <MinVerTaskPath Condition="'$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)task\net472\MinVer.MSBuild.dll</MinVerTaskPath>
   </PropertyGroup>
+
+  <UsingTask TaskName="MinVer.MSBuild.MinVerTask" AssemblyFile="$(MinVerTaskPath)" />
 
   <PropertyGroup>
     <MinVerDetailed>low</MinVerDetailed>
@@ -29,31 +33,20 @@
     <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MinVerTagPrefix=$(MinVerTagPrefix)" />
     <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MinVerVerbosity=$(MinVerVerbosity)" />
     <Message Importance="$(MinVerDetailed)" Text="MinVer: [input] MinVerVersionOverride=$(MinVerVersionOverride)" />
-    <ItemGroup>
-      <MinVerInputs Remove="@(MinVerInputs)" />
-      <MinVerConsoleOutput Remove="@(MinVerConsoleOutput)" />
-      <MinVerOutputVersion Remove="@(MinVerOutputVersion)" />
-    </ItemGroup>
-    <ItemGroup>
-      <MinVerInputs Include="&quot;$(MSBuildProjectDirectory)&quot;" />
-      <MinVerInputs Include="--auto-increment &quot;$(MinVerAutoIncrement)&quot;" />
-      <MinVerInputs Include="--build-metadata &quot;$(MinVerBuildMetadata)&quot;" />
-      <MinVerInputs Include="--default-pre-release-identifiers &quot;$(MinVerDefaultPreReleaseIdentifiers)&quot;" />
-      <MinVerInputs Include="--default-pre-release-phase &quot;$(MinVerDefaultPreReleasePhase)&quot;" />
-      <MinVerInputs Include="--ignore-height" Condition="'$(MinVerIgnoreHeight)' == 'true'" />
-      <MinVerInputs Include="--minimum-major-minor &quot;$(MinVerMinimumMajorMinor)&quot;" />
-      <MinVerInputs Include="--tag-prefix &quot;$(MinVerTagPrefix)&quot;" />
-      <MinVerInputs Include="--verbosity &quot;$(MinVerVerbosity)&quot;" />
-      <MinVerInputs Include="--version-override &quot;$(MinVerVersionOverride)&quot;" />
-    </ItemGroup>
-    <Exec Command="dotnet &quot;$(MSBuildThisFileDirectory)../minver/$(MinVerTargetFramework)/MinVer.dll&quot; @(MinVerInputs->'%(Identity)', ' ')" ConsoleToMSBuild="true" StandardOutputImportance="Low" >
-      <Output TaskParameter="ConsoleOutput" ItemName="MinVerConsoleOutput" />
-    </Exec>
-    <ItemGroup>
-      <MinVerOutputVersion Include="@(MinVerConsoleOutput)" Condition="'$([System.String]::new(`%(Identity)`).StartsWith(`MinVer:`))' != 'true'" />
-    </ItemGroup>
+    <MinVerTask GitWorkingDirectory="$(MSBuildProjectDirectory)"
+      AutoIncrement="$(MinVerAutoIncrement)"
+      BuildMetadata="$(MinVerBuildMetadata)"
+      DefaultPreReleaseIdentifiers="$(MinVerDefaultPreReleaseIdentifiers)"
+      DefaultPreReleasePhase="$(MinVerDefaultPreReleasePhase)"
+      IgnoreHeight="$(MinVerIgnoreHeight)"
+      MinimumMajorMinor="$(MinVerMinimumMajorMinor)"
+      TagPrefix="$(MinVerTagPrefix)"
+      Verbosity="$(MinVerVerbosity)"
+      VersionOverride="$(MinVerVersionOverride)"
+      TargetFramework="$(MinVerTargetFramework)">
+        <Output TaskParameter="Version" PropertyName="MinVerVersion" />
+    </MinVerTask>
     <PropertyGroup>
-      <MinVerVersion>@(MinVerOutputVersion)</MinVerVersion>
       <MinVerMajor>$(MinVerVersion.Split(`.`)[0])</MinVerMajor>
       <MinVerMinor>$(MinVerVersion.Split(`.`)[1])</MinVerMinor>
       <MinVerPatch>$(MinVerVersion.Split(`.`)[2].Split(`-`)[0].Split(`+`)[0])</MinVerPatch>

--- a/MinVerTests.Packages/MultipleProjects.cs
+++ b/MinVerTests.Packages/MultipleProjects.cs
@@ -47,14 +47,14 @@ public class MultipleProjects
         var versionCalculations = standardOutput
             .ToNonEmptyLines()
             .Select(line => line.Trim())
-            .Where(line => line.StartsWith("MinVer: Calculated version ", StringComparison.OrdinalIgnoreCase));
+            .Where(line => line.StartsWith("MinVer: Calculated version ", StringComparison.OrdinalIgnoreCase) || line.StartsWith("MinVerTask: Result cache has value", StringComparison.OrdinalIgnoreCase));
 
         Assert.Collection(
             versionCalculations,
             message => Assert.Equal("MinVer: Calculated version 2.3.4.", message),
             message => Assert.Equal("MinVer: Calculated version 5.6.7.", message),
-            message => Assert.Equal("MinVer: Calculated version 2.3.4.", message),
-            message => Assert.Equal("MinVer: Calculated version 5.6.7.", message));
+            message => Assert.Equal("MinVerTask: Result cache has value. Skipping MinVer and using cached result: 2.3.4", message),
+            message => Assert.Equal("MinVerTask: Result cache has value. Skipping MinVer and using cached result: 5.6.7", message));
 
         Assert.Collection(
             actual,


### PR DESCRIPTION
This PR adds an MSBuild task assembly that is used to call MinVer instead of using the built-in `Exec` task that was used previously.

This custom task lets us cache the result of the MinVer call, so that MinVer only needs to be invoked once per build.

The cache key uses all of the relevant MinVer input parameters, so if projects are configured to use different values, they will properly not share cache results.

This is the first step of addressing #112.