### PR TITLE
WIP - Exploration to expose extended git details to MSBuild

### DIFF
--- a/MinVer.Lib/Git.cs
+++ b/MinVer.Lib/Git.cs
@@ -8,6 +8,7 @@ namespace MinVer.Lib;
 internal static class Git
 {
     private static readonly char[] newLineChars = ['\r', '\n',];
+    private static readonly char[] spaceChars = [' '];
 
     public static bool IsWorkingDirectory(string directory, ILogger log) => GitCommand.TryRun("status --short", directory, log, out _);
 
@@ -30,7 +31,7 @@ internal static class Git
         var commits = new Dictionary<string, Commit>();
 
         foreach (var shas in lines
-            .Select(line => line.Split(" ", StringSplitOptions.RemoveEmptyEntries)))
+            .Select(line => line.Split(spaceChars, StringSplitOptions.RemoveEmptyEntries)))
         {
             commits.GetOrAdd(shas[0], () => new Commit(shas[0]))
                 .Parents.AddRange(shas.Skip(1).Select(parentSha => commits.GetOrAdd(parentSha, () => new Commit(parentSha))));
@@ -45,7 +46,7 @@ internal static class Git
         GitCommand.TryRun("show-ref --tags --dereference", directory, log, out var output)
             ? output
                 .Split(newLineChars, StringSplitOptions.RemoveEmptyEntries)
-                .Select(line => line.Split(" ", 2))
+                .Select(line => line.Split(spaceChars, 2))
                 .Select(tokens => (tokens[1][10..].RemoveFromEnd("^{}"), tokens[0]))
             : Enumerable.Empty<(string, string)>();
 

--- a/MinVer.Lib/MinVer.Lib.csproj
+++ b/MinVer.Lib/MinVer.Lib.csproj
@@ -2,12 +2,13 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="NuGet.Versioning" Version="6.8.0" />
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
   </ItemGroup>
 
 </Project>

--- a/MinVer.Lib/Version.cs
+++ b/MinVer.Lib/Version.cs
@@ -40,16 +40,26 @@ public class Version : SemanticVersion
             : new Version(minMajorMinor.Major, minMajorMinor.Minor, 0, defaultPreReleaseIdentifiers.ToList(), this.height, this.Metadata);
     }
 
-    public Version WithHeight(int newHeight, VersionPart autoIncrement, IEnumerable<string> defaultPreReleaseIdentifiers) =>
-        this.preReleaseIdentifiers.Count == 0 && newHeight > 0
-            ? autoIncrement switch
+    public Version WithHeight(int newHeight, VersionPart autoIncrement, IEnumerable<string> defaultPreReleaseIdentifiers, bool includeDefaultPreReleaseIdentifiersWithPrereleases)
+    {
+        if (this.preReleaseIdentifiers.Count == 0 && newHeight > 0)
+        {
+            return autoIncrement switch
             {
                 VersionPart.Major => new Version(this.Major + 1, 0, 0, defaultPreReleaseIdentifiers.ToList(), newHeight, ""),
                 VersionPart.Minor => new Version(this.Major, this.Minor + 1, 0, defaultPreReleaseIdentifiers.ToList(), newHeight, ""),
                 VersionPart.Patch => new Version(this.Major, this.Minor, this.Patch + 1, defaultPreReleaseIdentifiers.ToList(), newHeight, ""),
                 _ => throw new ArgumentOutOfRangeException(nameof(autoIncrement)),
-            }
-            : new Version(this.Major, this.Minor, this.Patch, this.preReleaseIdentifiers, newHeight, newHeight == 0 ? this.Metadata : "");
+            };
+        }
+        else
+        {
+            var newPreReleaseIdentifiers = includeDefaultPreReleaseIdentifiersWithPrereleases && newHeight > 0
+                ? [.. this.preReleaseIdentifiers, .. defaultPreReleaseIdentifiers]
+                : this.preReleaseIdentifiers;
+            return new Version(this.Major, this.Minor, this.Patch, newPreReleaseIdentifiers, newHeight, newHeight == 0 ? this.Metadata : "");
+        }
+    }
 
     public Version AddBuildMetadata(string newBuildMetadata)
     {

--- a/MinVer.Lib/VersionData.cs
+++ b/MinVer.Lib/VersionData.cs
@@ -1,0 +1,3 @@
+﻿namespace MinVer.Lib;
+
+public record VersionData(string Version, int Major, int Minor, int Patch, string Label, int Height, string Sha, string ShortSha);

--- a/MinVerTests.Lib/DefaultPreReleaseIdentifiers.cs
+++ b/MinVerTests.Lib/DefaultPreReleaseIdentifiers.cs
@@ -11,6 +11,48 @@ namespace MinVerTests.Lib;
 public static class DefaultPreReleaseIdentifiers
 {
     [Theory]
+    [InlineData("1.2.3-rc.1", VersionPart.Major, "1.2.3-rc.1.1")]
+    [InlineData("1.2.3-rc.1", VersionPart.Minor, "1.2.3-rc.1.1")]
+    [InlineData("1.2.3-rc.1", VersionPart.Patch, "1.2.3-rc.1.1")]
+    public static async Task PreReleaseVersionIncrement(string tag, VersionPart autoIncrement, string expectedVersion)
+    {
+        // arrange
+        var path = MethodBase.GetCurrentMethod().GetTestDirectory((tag, autoIncrement));
+        await EnsureEmptyRepositoryAndCommit(path);
+        await Tag(path, tag);
+        await Commit(path);
+
+        // act
+        var actualVersion = Versioner.GetVersion(path, "", MajorMinor.Default, "", autoIncrement, PreReleaseIdentifiers.Default, false, NullLogger.Instance);
+
+        // assert
+        Assert.Equal(expectedVersion, actualVersion.ToString());
+    }
+
+    [Theory]
+    [InlineData("1.2.3", "alpha", "1.2.4-alpha.1")]
+    [InlineData("1.2.3-rc.1", "alpha", "1.2.3-rc.1.alpha.1")]
+    [InlineData("0.0.0", "preview.x", "0.0.1-preview.x.1")]
+    public static async Task AlwaysIncludeDefaultPreRelease(string tag, string identifiers, string expectedVersion)
+    {
+        // arrange
+        var path = MethodBase.GetCurrentMethod().GetTestDirectory(identifiers);
+        await EnsureEmptyRepositoryAndCommit(path);
+        await Tag(path, tag);
+        await Commit(path);
+
+#pragma warning disable CA1062 // Validate arguments of public methods
+        var identifierList = identifiers.Split('.');
+#pragma warning restore CA1062 // Validate arguments of public methods
+
+        // act
+        var actualData = Versioner.GetVersionData(path, "", MajorMinor.Default, "", default, identifierList, false, true, NullLogger.Instance);
+
+        // assert
+        Assert.Equal(expectedVersion, actualData.Version);
+    }
+
+    [Theory]
     [InlineData("alpha.0", "0.0.0-alpha.0")]
     [InlineData("preview.x", "0.0.0-preview.x")]
     public static async Task Various(string identifiers, string expectedVersion)

--- a/SomeVer.sln
+++ b/SomeVer.sln
@@ -1,0 +1,70 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34701.34
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinVerTests.Lib", "MinVerTests.Lib\MinVerTests.Lib.csproj", "{57307B80-9750-4D4F-91DC-EE28EC89EDDD}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinVer.Lib", "MinVer.Lib\MinVer.Lib.csproj", "{EE44EA11-CEBE-49C7-9F23-EE8AE6FDFCFB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Targets", "targets\Targets.csproj", "{0F266E8B-E818-41A8-B93C-9E80E9446AC6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinVer", "MinVer\MinVer.csproj", "{EE9A19AA-0EDC-446F-8FD8-78A066E27B71}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "minver-cli", "minver-cli\minver-cli.csproj", "{34A5ECB1-400C-462A-B2B8-2B7136BE162A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinVerTests.Infra", "MinVerTests.Infra\MinVerTests.Infra.csproj", "{AA98F752-F8EF-447D-BC85-4F277CAF4B82}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MinVerTests.Packages", "MinVerTests.Packages\MinVerTests.Packages.csproj", "{694ECAC7-FD05-4550-A4FB-8F497D29ECB0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SomeVer", "SomeVer\SomeVer.csproj", "{03B3ECED-089C-4CC5-BC87-B9F90D852988}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{57307B80-9750-4D4F-91DC-EE28EC89EDDD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{57307B80-9750-4D4F-91DC-EE28EC89EDDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{57307B80-9750-4D4F-91DC-EE28EC89EDDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{57307B80-9750-4D4F-91DC-EE28EC89EDDD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE44EA11-CEBE-49C7-9F23-EE8AE6FDFCFB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE44EA11-CEBE-49C7-9F23-EE8AE6FDFCFB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE44EA11-CEBE-49C7-9F23-EE8AE6FDFCFB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE44EA11-CEBE-49C7-9F23-EE8AE6FDFCFB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F266E8B-E818-41A8-B93C-9E80E9446AC6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F266E8B-E818-41A8-B93C-9E80E9446AC6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F266E8B-E818-41A8-B93C-9E80E9446AC6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F266E8B-E818-41A8-B93C-9E80E9446AC6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EE9A19AA-0EDC-446F-8FD8-78A066E27B71}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EE9A19AA-0EDC-446F-8FD8-78A066E27B71}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EE9A19AA-0EDC-446F-8FD8-78A066E27B71}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EE9A19AA-0EDC-446F-8FD8-78A066E27B71}.Release|Any CPU.Build.0 = Release|Any CPU
+		{34A5ECB1-400C-462A-B2B8-2B7136BE162A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{34A5ECB1-400C-462A-B2B8-2B7136BE162A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{34A5ECB1-400C-462A-B2B8-2B7136BE162A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{34A5ECB1-400C-462A-B2B8-2B7136BE162A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AA98F752-F8EF-447D-BC85-4F277CAF4B82}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AA98F752-F8EF-447D-BC85-4F277CAF4B82}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AA98F752-F8EF-447D-BC85-4F277CAF4B82}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AA98F752-F8EF-447D-BC85-4F277CAF4B82}.Release|Any CPU.Build.0 = Release|Any CPU
+		{694ECAC7-FD05-4550-A4FB-8F497D29ECB0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{694ECAC7-FD05-4550-A4FB-8F497D29ECB0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{694ECAC7-FD05-4550-A4FB-8F497D29ECB0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{694ECAC7-FD05-4550-A4FB-8F497D29ECB0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{03B3ECED-089C-4CC5-BC87-B9F90D852988}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{03B3ECED-089C-4CC5-BC87-B9F90D852988}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{03B3ECED-089C-4CC5-BC87-B9F90D852988}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{03B3ECED-089C-4CC5-BC87-B9F90D852988}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {9A50D1D0-1F93-4845-829D-C33C590C82F4}
+	EndGlobalSection
+	GlobalSection(Performance) = preSolution
+		HasPerformanceSessions = true
+	EndGlobalSection
+EndGlobal

--- a/SomeVer/SomeVer.csproj
+++ b/SomeVer/SomeVer.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>default</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="buildMultiTargeting\SomeVer.targets" />
+    <None Remove="build\SomeVer.targets" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="build\SomeVer.targets" CopyToOutputDirectory="PreserveNewest"  PackagePath="build"/>
+    <Content Include="buildMultiTargeting\SomeVer.targets" CopyToOutputDirectory="PreserveNewest" PackagePath="buildMultiTargeting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MinVer.Lib\MinVer.Lib.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.9.5" />
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers" />
+  </ItemGroup>
+
+</Project>

--- a/SomeVer/SomeVerTask.cs
+++ b/SomeVer/SomeVerTask.cs
@@ -1,0 +1,123 @@
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using MinVer.Lib;
+
+namespace SomeVer;
+
+public class SomeVerTask : Microsoft.Build.Utilities.Task
+{
+    public string? AutoIncrement { get; set; }
+
+    public string? BuildMetadata { get; set; }
+
+    public string[]? DefaultPreReleaseIdentifiers { get; set; }
+
+    public string? IgnoreHeight { get; set; }
+
+    public string? IncludeDefaultPreReleaseIdentifiersWithPrereleases { get; set; }
+
+    public string? MinimumMajorMinor { get; set; }
+
+    public string? TagPrefix { get; set; }
+
+    [Required]
+    public string? WorkingDirectory { get; set; }
+
+    [Output]
+    public string Version { get; private set; } = string.Empty;
+
+    [Output]
+    public int Major { get; private set; } = 0;
+
+    [Output]
+    public int Minor { get; private set; } = 0;
+
+    [Output]
+    public int Patch { get; private set; } = 0;
+
+    [Output]
+    public string Label { get; private set; } = string.Empty;
+
+    [Output]
+    public int Height { get; private set; } = 0;
+
+    [Output]
+    public string Sha { get; private set; } = string.Empty;
+
+    [Output]
+    public string ShortSha { get; private set; } = string.Empty;
+
+    public override bool Execute()
+    {
+        var log = new MSBuildMinVerLogger(this.Log);
+
+        this.WorkingDirectory ??= Environment.CurrentDirectory;
+
+        try
+        {
+            var data = Versioner.GetVersionData(
+                this.WorkingDirectory,
+                this.TagPrefix ?? string.Empty,
+                MajorMinor.TryParse(this.MinimumMajorMinor, out var minMajorMinor) ? minMajorMinor : MajorMinor.Default,
+                this.BuildMetadata ?? string.Empty,
+                Enum.TryParse<VersionPart>(this.AutoIncrement, ignoreCase: true, out var autoIncrement) ? autoIncrement : default,
+                this.DefaultPreReleaseIdentifiers ?? PreReleaseIdentifiers.Default,
+                bool.TryParse(this.IgnoreHeight, out var ignoreHeight) && ignoreHeight,
+                bool.TryParse(this.IncludeDefaultPreReleaseIdentifiersWithPrereleases, out var includeDefaultPreReleaseIdentifiersWithPrereleases) && includeDefaultPreReleaseIdentifiersWithPrereleases,
+                log);
+
+            this.Version = data.Version;
+            this.Major = data.Major;
+            this.Minor = data.Minor;
+            this.Minor = data.Patch;
+            this.Patch = data.Patch;
+            this.Label = data.Label;
+            this.Sha = data.Sha;
+            this.ShortSha = data.ShortSha;
+            this.Height = data.Height;
+
+            return true;
+        }
+        catch (NoGitException ex)
+        {
+            this.Log.LogErrorFromException(ex);
+            return false;
+        }
+    }
+
+    private sealed class MSBuildMinVerLogger(TaskLoggingHelper log) : MinVer.Lib.ILogger
+    {
+        public bool IsTraceEnabled { get; }
+
+        public bool IsDebugEnabled { get; }
+
+        public bool IsInfoEnabled { get; } = true;
+
+        public bool IsWarnEnabled { get; } = true;
+
+        public bool Debug(string message)
+        {
+            log.LogMessage(MessageImportance.Low, message);
+            return true;
+        }
+
+        public bool Info(string message)
+        {
+            log.LogMessage(MessageImportance.Low, message);
+            return true;
+        }
+
+
+        public bool Trace(string message)
+        {
+            log.LogMessage(MessageImportance.Low, message);
+            return true;
+        }
+
+        public bool Warn(int code, string message)
+        {
+            log.LogWarning(message);
+            return true;
+        }
+    }
+}

--- a/SomeVer/build/SomeVer.targets
+++ b/SomeVer/build/SomeVer.targets
@@ -1,0 +1,80 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildAssemblyVersion)' == '' Or '$(MSBuildAssemblyVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);SomeVer</GenerateNuspecDependsOn>
+    <GetPackageVersionDependsOn>$(GetPackageVersionDependsOn);SomeVer</GetPackageVersionDependsOn>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SomeVerDetailed>low</SomeVerDetailed>
+    <SomeVerDetailed Condition="'$(SomeVerVerbosity)' == 'detailed' Or '$(SomeVerVerbosity)' == 'd' Or '$(SomeVerVerbosity)' == 'diagnostic' Or '$(SomeVerVerbosity)' == 'diag'">high</SomeVerDetailed>
+    <SomeVerTargetFramework>net6.0</SomeVerTargetFramework>
+    <SomeVerTargetFramework Condition="'$(MSBuildAssemblyVersion)' &gt;= '17.4'">net7.0</SomeVerTargetFramework>
+    <SomeVerTargetFramework Condition="'$(MSBuildAssemblyVersion)' &gt;= '17.8'">net8.0</SomeVerTargetFramework>
+    <NoWarn>$(NoWarn);NU5105</NoWarn>
+  </PropertyGroup>
+
+  <Target Name="_SomeVerClean" BeforeTargets="Clean" DependsOnTargets="SomeVer" Condition="'$(GeneratePackageOnBuild)' == 'true'" />
+
+  <UsingTask TaskName="SomeVerTask" AssemblyFile="..\SomeVer.dll" />
+
+  <Target Name="SomeVer" BeforeTargets="BeforeCompile;GetAssemblyVersion;CoreCompile" Condition="'$(DesignTimeBuild)' != 'true' AND '$(SomeVerSkip)' != 'true'">
+    <Error Condition="'$(UsingMicrosoftNETSdk)' != 'true'" Code="SomeVer0001" Text="SomeVer only works in SDK-style projects." />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [input] MSBuildProjectDirectory=$(MSBuildProjectDirectory)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [input] SomeVerAutoIncrement=$(SomeVerAutoIncrement)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [input] SomeVerBuildMetadata=$(SomeVerBuildMetadata)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [input] SomeVerDefaultPreReleaseIdentifiers=$(SomeVerDefaultPreReleaseIdentifiers)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [input] SomeVerDefaultPreReleasePhase=$(SomeVerDefaultPreReleasePhase)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [input] SomeVerIgnoreHeight=$(SomeVerIgnoreHeight)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [input] SomeVerIncludeDefaultPreReleaseIdentifiersWithPrereleases=$(SomeVerIncludeDefaultPreReleaseIdentifiersWithPrereleases)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [input] SomeVerMinimumMajorMinor=$(SomeVerMinimumMajorMinor)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [input] SomeVerTagPrefix=$(SomeVerTagPrefix)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [input] SomeVerVerbosity=$(SomeVerVerbosity)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [input] SomeVerVersionOverride=$(SomeVerVersionOverride)" />
+    <ItemGroup>
+      <SomeVerInputs Remove="@(SomeVerInputs)" />
+      <SomeVerConsoleOutput Remove="@(SomeVerConsoleOutput)" />
+      <SomeVerOutputVersion Remove="@(SomeVerOutputVersion)" />
+    </ItemGroup>
+
+    <SomeVerTask
+        AutoIncrement="$(SomeVerAutoIncrement)"
+        BuildMetadata="$(SomeVerBuildMetadata)"
+        DefaultPreReleaseIdentifiers="$(SomeVerDefaultPreReleaseIdentifiers)"
+        IgnoreHeight="$(SomeVerIgnoreHeight)"
+        IncludeDefaultPreReleaseIdentifiersWithPrereleases="$(SomeVerIncludeDefaultPreReleaseIdentifiersWithPrereleases)"
+        MinimumMajorMinor="$(SomeVerMinimumMajorMinor)"
+        TagPrefix="$(SomeVerTagPrefix)"
+        WorkingDirectory="$(MSBuildProjectDirectory)">
+      <Output TaskParameter="Version" PropertyName="SomeVerVersion" />
+      <Output TaskParameter="Major" PropertyName="SomeVerMajor" />
+      <Output TaskParameter="Minor" PropertyName="SomeVerMinor" />
+      <Output TaskParameter="Patch" PropertyName="SomeVerPatch" />
+      <Output TaskParameter="Label" PropertyName="SomeVerLabel" />
+      <Output TaskParameter="Sha" PropertyName="SomeVerSha" />
+      <Output TaskParameter="ShortSha" PropertyName="SomeVerShortSha" />
+      <Output TaskParameter="Height" PropertyName="SomeVerHeight" />
+    </SomeVerTask>
+    <PropertyGroup>
+      <AssemblyVersion>$(SomeVerMajor).0.0.0</AssemblyVersion>
+      <FileVersion>$(SomeVerMajor).$(SomeVerMinor).$(SomeVerPatch).$(SomeVerHeight)</FileVersion>
+      <InformationalVersion>$(SomeVerVersion)</InformationalVersion>
+      <PackageVersion>$(SomeVerMajor).$(SomeVerMinor).$(SomeVerPatch)</PackageVersion>
+      <PackageVersion Condition="'$(SomeVerLabel)' != ''">$(PackageVersion)-$(SomeVerLabel)</PackageVersion>
+      <Version>$(PackageVersion)</Version>
+    </PropertyGroup>
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [output] SomeVerVersion=$(SomeVerVersion)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [output] SomeVerMajor=$(SomeVerMajor)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [output] SomeVerMinor=$(SomeVerMinor)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [output] SomeVerPatch=$(SomeVerPatch)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [output] SomeVerLabel=$(SomeVerLabel)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [output] SomeVerBuildMetadata=$(SomeVerBuildMetadata)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [output] AssemblyVersion=$(AssemblyVersion)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [output] FileVersion=$(FileVersion)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [output] InformationalVersion=$(InformationalVersion)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [output] PackageVersion=$(PackageVersion)" />
+    <Message Importance="$(SomeVerDetailed)" Text="SomeVer: [output] Version=$(Version)" />
+  </Target>
+
+</Project>

--- a/SomeVer/buildMultiTargeting/SomeVer.targets
+++ b/SomeVer/buildMultiTargeting/SomeVer.targets
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildAssemblyVersion)' == '' Or '$(MSBuildAssemblyVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <Import Project="../build/SomeVer.targets" />
+</Project>


### PR DESCRIPTION
@adamralph I'm opening this PR to see if you are interested in changes like these. It exposes more git information to MSBuild that allows us to use the MinVer concepts in our more complicated build systems like in the WiX Toolset. 

If you are interested in these additions, I'll need to clean up the code quite a bit, and I would appreciate any feedback you have at this time so that I can factor it to your liking.

If you are NOT interested in the complexity added by this PR, that's totally cool. I really appreciate the ideas you put forward in MinVer. It changed (simplified!) the way I think about versioning using git.

There are two "features" in here. I'm sorry. I should have separated them into separate commits, and I will do that if this PR interests you.

1. Expose the various pieces of the git version to MSBuild. This allows us to do various string concatenations and (in some cases) math operations in MSBuild .targets files to address the various versions in our build system.

2. Adds a boolean to include the default pre-release labels even when the tag has pre-release information. We use default pre-release labels like `dev` on all dev builds. After releasing an `rc-1` we like the dev builds to still have the `dev` label, like `1.0.0-rc.1.dev.1`. This is mostly a vanity feature, but it turned out to be pretty straightforward to wire in so I took a shot at it. If you like this feature, I'd also add it to the minver.exe to maintain consistency.

Let me know if you are interested. Again, I know the code needs to be cleaned up but I didn't want to do too much if it turned out this added more complexity than you want in MinVer (that's why I jokingly called the new MSBuild task `SomeVer` 😆).