### PR TITLE
Revert "avoid a race between MSBuild.Caching net472 and its inclusion in the MinVer package"

### DIFF
--- a/MSBuild.Caching/MSBuild.Caching.csproj
+++ b/MSBuild.Caching/MSBuild.Caching.csproj
@@ -4,8 +4,6 @@
     <IsPackable>false</IsPackable>
     <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
-    <!-- avoid a race between the build of the net472 target and its inclusion in the MinVer package -->
-    <BuildInParallel>false</BuildInParallel>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This reverts commit 1c452363e7d2ca001748877db3340be868cac128.

That attempt [didn't work](https://github.com/adamralph/minver/actions/runs/19536532935/job/55931929506#step:6:49).